### PR TITLE
KllamaDemo: Transformer Explainer + Qwen3-0.6B (6 tabs, Q3_K_S quant)

### DIFF
--- a/KllamaDemo/README.md
+++ b/KllamaDemo/README.md
@@ -1,20 +1,30 @@
-# KllamaDemo — Qwen3-0.6B browser playground
+# KllamaDemo — Transformer Explainer on SKaiNET
 
-A Compose Multiplatform showcase of SKaiNET-transformers. The app ships
-with an embedded **Qwen3-0.6B** model (Q4_K_M GGUF, ~400 MB) and runs in
-the browser, on JVM desktop, on Android, and on iOS.
+A Compose Multiplatform / KMP / SKaiNET analog of the
+[Polo Club Transformer Explainer](https://poloclub.github.io/transformer-explainer/),
+running fully in the browser (and on JVM desktop, Android, iOS). The app
+ships with an embedded **Qwen3-0.6B** model (Q3_K_S GGUF, ~280 MB) and
+visualizes what the transformer is doing as it produces each token.
 
 ## What it demonstrates
 
-Tabbed UI driven by a single loaded model:
+A multi-tab UI driven by a single loaded model. The headline tab is the
+**Visualize** explainer; the other tabs reuse the same runtime to show
+related SKaiNET-transformer capabilities.
 
-- **Tokenizer playground** — type text, see how Qwen's BPE tokenizer
-  splits it into token IDs. No inference, instant feedback.
-- **Chat** — Qwen3 ChatML template applied inline, streaming tokens
-  produced via `OptimizedLLMRuntime.generate`.
-
-More tabs (streaming raw completion, en↔zh translation, tool calling
-with `get_current_time`) land in follow-up commits.
+- **Visualize** *(headline)* — type a prompt, click **Step**, watch the
+  next token be generated. See an architecture diagram of the 24-block
+  decoder stack, the post-softmax **attention heatmap** for any
+  block/head, the **residual stream** values out of any block, and the
+  top-10 **next-token probability bars**. Step token-by-token to see
+  the state of inference evolve.
+- **Tokenizer playground** — type text, see Qwen's BPE breakdown
+  into (id, decoded) pairs. Instant.
+- **Chat** — Qwen3 ChatML template applied inline, streaming tokens.
+- **Streaming completion** — raw prompt, no template, token-by-token.
+- **Translation** — en↔zh via a translation system prompt.
+- **Tool call** *(experimental)* — two-turn round-trip with a
+  `get_current_time` tool.
 
 ## One-time setup — fetch the model
 
@@ -25,7 +35,7 @@ fetch script before building:
 ./scripts/fetch-qwen-model.sh
 ```
 
-The script downloads `Qwen3-0.6B-Q4_K_M.gguf` from
+The script downloads `Qwen3-0.6B-Q3_K_S.gguf` from
 [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)
 into `composeApp/src/commonMain/composeResources/files/`. It's
 idempotent and skips on subsequent runs.
@@ -38,8 +48,8 @@ idempotent and skips on subsequent runs.
 ./gradlew :composeApp:wasmJsBrowserDevelopmentRun
 ```
 
-The first page load downloads the full ~400 MB bundle including the
-embedded model. Subsequent loads hit the browser HTTP cache.
+The first page load downloads the full ~295 MB bundle including the
+embedded Q3_K_S model. Subsequent loads hit the browser HTTP cache.
 
 ### Desktop (JVM)
 
@@ -47,8 +57,9 @@ embedded model. Subsequent loads hit the browser HTTP cache.
 ./gradlew :composeApp:run
 ```
 
-Model load takes ~40 s on first launch (FP32 dequantization of 600M
-parameters). Subsequent chat tokens stream at ~1-3 tok/s on CPU.
+Model load takes ~30 s on first launch (FP32 dequantization of 600M
+parameters from the smaller Q3_K_S quant). Subsequent chat tokens
+stream at ~1-3 tok/s on CPU.
 
 ### Android
 
@@ -73,7 +84,7 @@ under the **Apache License 2.0**.
 - Model card: https://huggingface.co/Qwen/Qwen3-0.6B
 - GGUF build used:
   [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)
-  (Q4_K_M quantization)
+  (Q3_K_S quantization)
 - License text: [THIRD_PARTY_LICENSES/Apache-2.0.txt](./THIRD_PARTY_LICENSES/Apache-2.0.txt)
 - Attribution: [THIRD_PARTY_LICENSES/NOTICE](./THIRD_PARTY_LICENSES/NOTICE)
 

--- a/KllamaDemo/README.md
+++ b/KllamaDemo/README.md
@@ -1,95 +1,101 @@
-This is a Kotlin Multiplatform project targeting Android, iOS, Web, Desktop (JVM), Server.
+# KllamaDemo — Qwen3-0.6B browser playground
 
-* [/composeApp](./composeApp/src) is for code that will be shared across your Compose Multiplatform applications.
-  It contains several subfolders:
-  - [commonMain](./composeApp/src/commonMain/kotlin) is for code that’s common for all targets.
-  - Other folders are for Kotlin code that will be compiled for only the platform indicated in the folder name.
-    For example, if you want to use Apple’s CoreCrypto for the iOS part of your Kotlin app,
-    the [iosMain](./composeApp/src/iosMain/kotlin) folder would be the right place for such calls.
-    Similarly, if you want to edit the Desktop (JVM) specific part, the [jvmMain](./composeApp/src/jvmMain/kotlin)
-    folder is the appropriate location.
+A Compose Multiplatform showcase of SKaiNET-transformers. The app ships
+with an embedded **Qwen3-0.6B** model (Q4_K_M GGUF, ~400 MB) and runs in
+the browser, on JVM desktop, on Android, and on iOS.
 
-* [/iosApp](./iosApp/iosApp) contains iOS applications. Even if you’re sharing your UI with Compose Multiplatform,
-  you need this entry point for your iOS app. This is also where you should add SwiftUI code for your project.
+## What it demonstrates
 
-* [/server](./server/src/main/kotlin) is for the Ktor server application.
+Tabbed UI driven by a single loaded model:
 
-* [/shared](./shared/src) is for the code that will be shared between all targets in the project.
-  The most important subfolder is [commonMain](./shared/src/commonMain/kotlin). If preferred, you
-  can add code to the platform-specific folders here too.
+- **Tokenizer playground** — type text, see how Qwen's BPE tokenizer
+  splits it into token IDs. No inference, instant feedback.
+- **Chat** — Qwen3 ChatML template applied inline, streaming tokens
+  produced via `OptimizedLLMRuntime.generate`.
 
-### Build and Run Android Application
+More tabs (streaming raw completion, en↔zh translation, tool calling
+with `get_current_time`) land in follow-up commits.
 
-To build and run the development version of the Android app, use the run configuration from the run widget
-in your IDE’s toolbar or build it directly from the terminal:
-- on macOS/Linux
-  ```shell
-  ./gradlew :composeApp:assembleDebug
-  ```
-- on Windows
-  ```shell
-  .\gradlew.bat :composeApp:assembleDebug
-  ```
+## One-time setup — fetch the model
 
-### Build and Run Desktop (JVM) Application
+The 400 MB GGUF is not committed (`*.gguf` is `.gitignore`'d). Run the
+fetch script before building:
 
-To build and run the development version of the desktop app, use the run configuration from the run widget
-in your IDE’s toolbar or run it directly from the terminal:
-- on macOS/Linux
-  ```shell
-  ./gradlew :composeApp:run
-  ```
-- on Windows
-  ```shell
-  .\gradlew.bat :composeApp:run
-  ```
+```shell
+./scripts/fetch-qwen-model.sh
+```
 
-### Build and Run Server
+The script downloads `Qwen3-0.6B-Q4_K_M.gguf` from
+[unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)
+into `composeApp/src/commonMain/composeResources/files/`. It's
+idempotent and skips on subsequent runs.
 
-To build and run the development version of the server, use the run configuration from the run widget
-in your IDE’s toolbar or run it directly from the terminal:
-- on macOS/Linux
-  ```shell
-  ./gradlew :server:run
-  ```
-- on Windows
-  ```shell
-  .\gradlew.bat :server:run
-  ```
+## Build and run
 
-### Build and Run Web Application
+### Browser (wasmJs — primary target)
 
-To build and run the development version of the web app, use the run configuration from the run widget
-in your IDE's toolbar or run it directly from the terminal:
-- for the Wasm target (faster, modern browsers):
-  - on macOS/Linux
-    ```shell
-    ./gradlew :composeApp:wasmJsBrowserDevelopmentRun
-    ```
-  - on Windows
-    ```shell
-    .\gradlew.bat :composeApp:wasmJsBrowserDevelopmentRun
-    ```
-- for the JS target (slower, supports older browsers):
-  - on macOS/Linux
-    ```shell
-    ./gradlew :composeApp:jsBrowserDevelopmentRun
-    ```
-  - on Windows
-    ```shell
-    .\gradlew.bat :composeApp:jsBrowserDevelopmentRun
-    ```
+```shell
+./gradlew :composeApp:wasmJsBrowserDevelopmentRun
+```
 
-### Build and Run iOS Application
+The first page load downloads the full ~400 MB bundle including the
+embedded model. Subsequent loads hit the browser HTTP cache.
 
-To build and run the development version of the iOS app, use the run configuration from the run widget
-in your IDE’s toolbar or open the [/iosApp](./iosApp) directory in Xcode and run it from there.
+### Desktop (JVM)
 
----
+```shell
+./gradlew :composeApp:run
+```
 
-Learn more about [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html),
-[Compose Multiplatform](https://github.com/JetBrains/compose-multiplatform/#compose-multiplatform),
-[Kotlin/Wasm](https://kotl.in/wasm/)…
+Model load takes ~40 s on first launch (FP32 dequantization of 600M
+parameters). Subsequent chat tokens stream at ~1-3 tok/s on CPU.
 
-We would appreciate your feedback on Compose/Web and Kotlin/Wasm in the public Slack channel [#compose-web](https://slack-chats.kotlinlang.org/c/compose-web).
-If you face any issues, please report them on [YouTrack](https://youtrack.jetbrains.com/newIssue?project=CMP).
+### Android
+
+```shell
+./gradlew :composeApp:assembleDebug
+```
+
+The debug APK includes the 400 MB model in `assets/` — too large for
+Play Store distribution as a single APK. A follow-up will split the
+model into an `assetPack` for AAB builds.
+
+### iOS
+
+Open `iosApp/iosApp.xcodeproj` in Xcode. The model ships as part of the
+iOS framework — the same caveat about bundle size applies.
+
+## Model & license
+
+This app bundles **Qwen3-0.6B** by Alibaba Cloud / Qwen team, licensed
+under the **Apache License 2.0**.
+
+- Model card: https://huggingface.co/Qwen/Qwen3-0.6B
+- GGUF build used:
+  [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)
+  (Q4_K_M quantization)
+- License text: [THIRD_PARTY_LICENSES/Apache-2.0.txt](./THIRD_PARTY_LICENSES/Apache-2.0.txt)
+- Attribution: [THIRD_PARTY_LICENSES/NOTICE](./THIRD_PARTY_LICENSES/NOTICE)
+
+## Project structure
+
+- `composeApp/` — Compose Multiplatform application. The playground UI
+  lives under `composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/`.
+- `shared/` — model-loading types, the Phase-0 inference spike
+  (`spike/QwenSpike.kt`), and the platform-detection scaffold used by
+  the older filesystem-picker chat (now superseded by the playground).
+- `server/` — Ktor server (unrelated to the playground).
+- `iosApp/` — iOS entry point.
+- `scripts/fetch-qwen-model.sh` — model downloader.
+- `THIRD_PARTY_LICENSES/` — Apache 2.0 + NOTICE for the bundled model.
+
+## Testing the inference plumbing
+
+A JVM JUnit smoke test under `shared/src/jvmTest/` loads the embedded
+GGUF directly from disk and runs a 5-token forward pass — proves the
+`QwenNetworkLoader` → `OptimizedLLMRuntime` → `generate(...)` chain
+works without any UI involvement:
+
+```shell
+./gradlew :shared:jvmTest --tests "*QwenSpike*"
+```

--- a/KllamaDemo/THIRD_PARTY_LICENSES/Apache-2.0.txt
+++ b/KllamaDemo/THIRD_PARTY_LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/KllamaDemo/THIRD_PARTY_LICENSES/NOTICE
+++ b/KllamaDemo/THIRD_PARTY_LICENSES/NOTICE
@@ -1,0 +1,9 @@
+This product bundles the Qwen3-0.6B language model (Q4_K_M quantization)
+released by Alibaba Cloud / Qwen team, distributed under the Apache License
+2.0 (see Apache-2.0.txt in this directory).
+
+Model source:  https://huggingface.co/Qwen/Qwen3-0.6B
+GGUF build:    https://huggingface.co/unsloth/Qwen3-0.6B-GGUF
+GGUF file:     Qwen3-0.6B-Q4_K_M.gguf  (~400 MB)
+
+Attribution: Qwen Team, Alibaba Cloud. See https://github.com/QwenLM/Qwen3.

--- a/KllamaDemo/THIRD_PARTY_LICENSES/NOTICE
+++ b/KllamaDemo/THIRD_PARTY_LICENSES/NOTICE
@@ -1,9 +1,9 @@
-This product bundles the Qwen3-0.6B language model (Q4_K_M quantization)
+This product bundles the Qwen3-0.6B language model (Q3_K_S quantization)
 released by Alibaba Cloud / Qwen team, distributed under the Apache License
 2.0 (see Apache-2.0.txt in this directory).
 
 Model source:  https://huggingface.co/Qwen/Qwen3-0.6B
 GGUF build:    https://huggingface.co/unsloth/Qwen3-0.6B-GGUF
-GGUF file:     Qwen3-0.6B-Q4_K_M.gguf  (~400 MB)
+GGUF file:     Qwen3-0.6B-Q3_K_S.gguf  (~280 MB)
 
 Attribution: Qwen Team, Alibaba Cloud. See https://github.com/QwenLM/Qwen3.

--- a/KllamaDemo/composeApp/build.gradle.kts
+++ b/KllamaDemo/composeApp/build.gradle.kts
@@ -132,16 +132,24 @@ val fetchQwenModel by tasks.registering(Exec::class) {
     commandLine("bash", scriptPath.asFile.absolutePath)
     inputs.file(scriptPath)
     val modelFile = rootProject.layout.projectDirectory.file(
-        "composeApp/src/commonMain/composeResources/files/qwen3-0.6b-Q4_K_M.gguf"
+        "composeApp/src/commonMain/composeResources/files/qwen3-0.6b-Q3_K_S.gguf"
     )
     outputs.file(modelFile)
-    onlyIf { !modelFile.asFile.exists() || modelFile.asFile.length() < 300L * 1024 * 1024 }
+    onlyIf { !modelFile.asFile.exists() || modelFile.asFile.length() < 200L * 1024 * 1024 }
 }
 
-// Make every Kotlin compile task depend on the model being on disk —
-// composeResources can't be packaged otherwise.
-tasks.matching { it.name.startsWith("compileKotlin") || it.name.startsWith("compileJava") }
-    .configureEach { dependsOn(fetchQwenModel) }
+// Make every Kotlin compile task AND every Compose-resources copy task
+// depend on the model being on disk. Without this, Gradle 9's strict
+// implicit-dependency validator fails because the resource-copy task
+// reads from a directory that fetchQwenModel writes into.
+tasks.matching {
+    it.name.startsWith("compileKotlin") ||
+        it.name.startsWith("compileJava") ||
+        it.name.startsWith("convertXmlValueResourcesFor") ||
+        it.name.startsWith("copyNonXmlValueResourcesFor") ||
+        it.name.startsWith("prepareComposeResourcesTaskFor") ||
+        it.name.startsWith("generateResourceAccessorsFor")
+}.configureEach { dependsOn(fetchQwenModel) }
 
 compose.desktop {
     application {

--- a/KllamaDemo/composeApp/build.gradle.kts
+++ b/KllamaDemo/composeApp/build.gradle.kts
@@ -116,12 +116,19 @@ dependencies {
     debugImplementation(libs.compose.uiTooling)
 }
 
-// Single source-of-truth for the JVM flags SKaiNET needs to engage
-// SIMD-accelerated CPU ops via the JDK Vector API (incubator). Used by
-// :composeApp:run, by tests, and by the packaged native distribution.
+// Single source-of-truth for the JVM flags SKaiNET needs:
+// - jdk.incubator.vector + --enable-preview engage the JDK Vector API
+//   for SIMD-accelerated CPU ops
+// - --enable-native-access=ALL-UNNAMED lets MemorySegment Arena (Panama
+//   FFM API) open without "restricted access" warnings on JDK 21+;
+//   DecoderGgufMemSegConverter uses Arena.ofShared() to back Q4_0/Q8_0
+//   tensors with off-heap memory for SIMD-packed matmul kernels.
+// - skainet.cpu.vector.enabled=true is the explicit opt-in switch the
+//   library inspects to confirm the host wants the SIMD code path.
 val skainetSimdJvmArgs = listOf(
     "--add-modules", "jdk.incubator.vector",
     "--enable-preview",
+    "--enable-native-access=ALL-UNNAMED",
     "-Dskainet.cpu.vector.enabled=true",
 )
 
@@ -141,10 +148,10 @@ val fetchQwenModel by tasks.registering(Exec::class) {
     commandLine("bash", scriptPath.asFile.absolutePath)
     inputs.file(scriptPath)
     val modelFile = rootProject.layout.projectDirectory.file(
-        "composeApp/src/commonMain/composeResources/files/qwen3-0.6b-Q3_K_S.gguf"
+        "composeApp/src/commonMain/composeResources/files/qwen3-0.6b-Q4_0.gguf"
     )
     outputs.file(modelFile)
-    onlyIf { !modelFile.asFile.exists() || modelFile.asFile.length() < 200L * 1024 * 1024 }
+    onlyIf { !modelFile.asFile.exists() || modelFile.asFile.length() < 300L * 1024 * 1024 }
 }
 
 // Make every Kotlin compile task AND every Compose-resources copy task

--- a/KllamaDemo/composeApp/build.gradle.kts
+++ b/KllamaDemo/composeApp/build.gradle.kts
@@ -116,13 +116,22 @@ dependencies {
     debugImplementation(libs.compose.uiTooling)
 }
 
+// Single source-of-truth for the JVM flags SKaiNET needs to engage
+// SIMD-accelerated CPU ops via the JDK Vector API (incubator). Used by
+// :composeApp:run, by tests, and by the packaged native distribution.
+val skainetSimdJvmArgs = listOf(
+    "--add-modules", "jdk.incubator.vector",
+    "--enable-preview",
+    "-Dskainet.cpu.vector.enabled=true",
+)
+
 tasks.withType<JavaExec>().configureEach {
-    jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector")
+    jvmArgs(skainetSimdJvmArgs)
     maxHeapSize = "16g"
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector")
+    jvmArgs(skainetSimdJvmArgs)
 }
 
 val fetchQwenModel by tasks.registering(Exec::class) {
@@ -159,10 +168,7 @@ compose.desktop {
             "-Xmx32G",                              // Increased heap for large models
             "-XX:+UseG1GC",                         // Better GC for large heaps
             "-XX:MaxGCPauseMillis=100",             // Reduce GC pauses
-            "--add-modules", "jdk.incubator.vector",
-            "--enable-preview",
-            "-Dskainet.cpu.vector.enabled=true"
-        )
+        ) + skainetSimdJvmArgs
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)

--- a/KllamaDemo/composeApp/build.gradle.kts
+++ b/KllamaDemo/composeApp/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.kotlinx.io.core)
+            implementation(libs.kotlinx.datetime)
             implementation(projects.shared)
             implementation("sk.ainet.ui:skainet-ui")
         }
@@ -123,6 +124,24 @@ tasks.withType<JavaExec>().configureEach {
 tasks.withType<Test>().configureEach {
     jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector")
 }
+
+val fetchQwenModel by tasks.registering(Exec::class) {
+    description = "Downloads the Qwen3-0.6B-Q4_K_M GGUF into composeResources/files. Skips if present."
+    group = "build setup"
+    val scriptPath = rootProject.layout.projectDirectory.file("scripts/fetch-qwen-model.sh")
+    commandLine("bash", scriptPath.asFile.absolutePath)
+    inputs.file(scriptPath)
+    val modelFile = rootProject.layout.projectDirectory.file(
+        "composeApp/src/commonMain/composeResources/files/qwen3-0.6b-Q4_K_M.gguf"
+    )
+    outputs.file(modelFile)
+    onlyIf { !modelFile.asFile.exists() || modelFile.asFile.length() < 300L * 1024 * 1024 }
+}
+
+// Make every Kotlin compile task depend on the model being on disk —
+// composeResources can't be packaged otherwise.
+tasks.matching { it.name.startsWith("compileKotlin") || it.name.startsWith("compileJava") }
+    .configureEach { dependsOn(fetchQwenModel) }
 
 compose.desktop {
     application {

--- a/KllamaDemo/composeApp/src/androidMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.android.kt
+++ b/KllamaDemo/composeApp/src/androidMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.android.kt
@@ -1,0 +1,14 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.types.FP32
+
+// Android API 35 still doesn't ship java.lang.foreign.Arena, so the JVM
+// fast path (DecoderGgufMemSegConverter) isn't available. Fall back to
+// the multiplatform Buffer-based loader.
+internal actual suspend fun buildQwenRuntime(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32> = buildQwenRuntimeFallback(ctx, bytes, bosTokenId)

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/App.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/App.kt
@@ -6,11 +6,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import sk.ainet.apps.kllama.chat.navigation.ChatNavigationHost
+import sk.ainet.apps.kllama.chat.playground.QwenPlaygroundHost
 import sk.ainet.ui.theme.SKaiNETTheme
 
 /**
- * Main app composable with SKaiNET Design System theming.
+ * Main app composable with SKaiNET Design System theming. Renders the
+ * Qwen3-0.6B playground (multi-tab, multi-mode showcase).
  */
 @Composable
 fun App(
@@ -22,7 +23,7 @@ fun App(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
         ) {
-            ChatNavigationHost()
+            QwenPlaygroundHost()
         }
     }
 }

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ChatTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ChatTab.kt
@@ -1,0 +1,109 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/**
+ * Chat tab using Qwen's ChatML template applied inline. Streams tokens as
+ * decoded text chunks. Stops on the `<|im_end|>` marker or after maxTokens.
+ */
+@Composable
+fun ChatTab(state: QwenLoadingState) {
+    var prompt by remember { mutableStateOf("Hello, can you introduce yourself in one sentence?") }
+    var response by remember { mutableStateOf("") }
+    var generating by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val scroll = rememberScrollState()
+
+    LaunchedEffect(response) { scroll.scrollTo(scroll.maxValue) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        OutlinedTextField(
+            value = prompt,
+            onValueChange = { prompt = it },
+            label = { Text("Prompt") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !generating,
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                enabled = state is QwenLoadingState.Ready && !generating,
+                onClick = {
+                    val ready = state as? QwenLoadingState.Ready ?: return@Button
+                    response = ""
+                    generating = true
+                    scope.launch {
+                        try {
+                            val templated = qwenChatML(systemPrompt = "You are Qwen, a helpful assistant.", user = prompt)
+                            val tokens = ready.tokenizer.encode(templated)
+                            ready.runtime.generateUntilImEnd(
+                                tokenizer = ready.tokenizer,
+                                promptTokens = tokens,
+                                maxTokens = 256,
+                                temperature = 0.7f,
+                                onText = { chunk -> response += chunk },
+                            )
+                        } finally {
+                            generating = false
+                        }
+                    }
+                },
+            ) { Text(if (generating) "Generating..." else "Send") }
+
+            Button(
+                enabled = !generating,
+                onClick = { response = "" },
+            ) { Text("Clear") }
+        }
+
+        when (state) {
+            is QwenLoadingState.Ready -> {
+                Text(
+                    text = if (response.isEmpty() && !generating) "(no response yet)" else response,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .verticalScroll(scroll)
+                        .padding(8.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            is QwenLoadingState.Failed -> Text(
+                "Model failed to load: ${state.message}",
+                color = MaterialTheme.colorScheme.error,
+            )
+            else -> Text(
+                "Model still loading. The first response can be slow on CPU; subsequent tokens are faster.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+private fun qwenChatML(systemPrompt: String, user: String): String =
+    "<|im_start|>system\n$systemPrompt<|im_end|>\n" +
+    "<|im_start|>user\n$user<|im_end|>\n" +
+    "<|im_start|>assistant\n"

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ChatTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ChatTab.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -21,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import sk.ainet.ui.components.LoadingIndicator
 
 /**
  * Chat tab using Qwen's ChatML template applied inline. Streams tokens as
@@ -48,7 +50,10 @@ fun ChatTab(state: QwenLoadingState) {
             enabled = !generating,
         )
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Button(
                 enabled = state is QwenLoadingState.Ready && !generating,
                 onClick = {
@@ -77,6 +82,10 @@ fun ChatTab(state: QwenLoadingState) {
                 enabled = !generating,
                 onClick = { response = "" },
             ) { Text("Clear") }
+
+            if (generating) {
+                LoadingIndicator(size = 24.dp)
+            }
         }
 
         when (state) {
@@ -95,10 +104,7 @@ fun ChatTab(state: QwenLoadingState) {
                 "Model failed to load: ${state.message}",
                 color = MaterialTheme.colorScheme.error,
             )
-            else -> Text(
-                "Model still loading. The first response can be slow on CPU; subsequent tokens are faster.",
-                style = MaterialTheme.typography.bodyMedium,
-            )
+            else -> ModelLoadingPanel(state)
         }
     }
 }

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -24,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import sk.ainet.apps.llm.generate
+import sk.ainet.ui.components.LoadingIndicator
 
 /**
  * Raw completion: prompt → token stream, no chat template. Useful for
@@ -51,7 +53,15 @@ fun CompletionTab(state: QwenLoadingState) {
             enabled = !generating,
         )
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (state !is QwenLoadingState.Ready) {
+            ModelLoadingPanel(state)
+            return@Column
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Button(
                 enabled = state is QwenLoadingState.Ready && !generating,
                 onClick = {
@@ -76,6 +86,10 @@ fun CompletionTab(state: QwenLoadingState) {
             ) { Text(if (generating) "Generating..." else "Complete") }
 
             Button(enabled = !generating, onClick = { output = "" }) { Text("Clear") }
+
+            if (generating) {
+                LoadingIndicator(size = 24.dp)
+            }
         }
 
         Text(

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import sk.ainet.apps.llm.generate
 
 /**
@@ -59,11 +61,13 @@ fun CompletionTab(state: QwenLoadingState) {
                     scope.launch {
                         try {
                             val tokens = ready.tokenizer.encode(prompt)
-                            ready.runtime.generate(
-                                prompt = tokens,
-                                steps = 128,
-                                temperature = 0.8f,
-                            ) { id -> output += ready.tokenizer.decode(id) }
+                            withContext(Dispatchers.Default) {
+                                ready.runtime.generate(
+                                    prompt = tokens,
+                                    steps = 128,
+                                    temperature = 0.8f,
+                                ) { id -> output += ready.tokenizer.decode(id) }
+                            }
                         } finally {
                             generating = false
                         }

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/CompletionTab.kt
@@ -1,0 +1,86 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import sk.ainet.apps.llm.generate
+
+/**
+ * Raw completion: prompt → token stream, no chat template. Useful for
+ * showing how the base model continues text.
+ */
+@Composable
+fun CompletionTab(state: QwenLoadingState) {
+    var prompt by remember { mutableStateOf("Once upon a time in a tiny village,") }
+    var output by remember { mutableStateOf("") }
+    var generating by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val scroll = rememberScrollState()
+
+    LaunchedEffect(output) { scroll.scrollTo(scroll.maxValue) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        OutlinedTextField(
+            value = prompt,
+            onValueChange = { prompt = it },
+            label = { Text("Prompt (no template applied)") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !generating,
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                enabled = state is QwenLoadingState.Ready && !generating,
+                onClick = {
+                    val ready = state as? QwenLoadingState.Ready ?: return@Button
+                    output = prompt
+                    generating = true
+                    scope.launch {
+                        try {
+                            val tokens = ready.tokenizer.encode(prompt)
+                            ready.runtime.generate(
+                                prompt = tokens,
+                                steps = 128,
+                                temperature = 0.8f,
+                            ) { id -> output += ready.tokenizer.decode(id) }
+                        } finally {
+                            generating = false
+                        }
+                    }
+                },
+            ) { Text(if (generating) "Generating..." else "Complete") }
+
+            Button(enabled = !generating, onClick = { output = "" }) { Text("Clear") }
+        }
+
+        Text(
+            text = if (output.isEmpty() && !generating) "(no output yet)" else output,
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(scroll)
+                .padding(8.dp),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ExplainerTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ExplainerTab.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,7 @@ import sk.ainet.apps.kllama.chat.playground.explainer.AttentionHeatmap
 import sk.ainet.apps.kllama.chat.playground.explainer.ResidualBars
 import sk.ainet.apps.kllama.chat.playground.explainer.StepSnapshot
 import sk.ainet.apps.kllama.chat.playground.explainer.TopKBars
+import sk.ainet.ui.components.LoadingIndicator
 
 /**
  * The headline tab. Step through Qwen3-0.6B token-by-token and inspect what
@@ -73,7 +75,10 @@ fun ExplainerTab(
             enabled = !promptProcessed && !working,
         )
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Button(
                 enabled = state is QwenLoadingState.Ready && !working,
                 onClick = {
@@ -124,11 +129,15 @@ fun ExplainerTab(
                 )
             }
 
-            if (snapshot != null) {
+            if (working) {
+                LoadingIndicator(size = 24.dp)
+            }
+
+            if (snapshot != null && !working) {
                 Text(
                     "Step latency: ${snapshot!!.elapsedMillis} ms",
                     style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier.wrapContentHeight().padding(top = 12.dp),
+                    modifier = Modifier.wrapContentHeight(),
                 )
             }
         }

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ExplainerTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ExplainerTab.kt
@@ -1,0 +1,207 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import sk.ainet.apps.kllama.chat.playground.explainer.ArchitectureDiagram
+import sk.ainet.apps.kllama.chat.playground.explainer.AttentionHeatmap
+import sk.ainet.apps.kllama.chat.playground.explainer.ResidualBars
+import sk.ainet.apps.kllama.chat.playground.explainer.StepSnapshot
+import sk.ainet.apps.kllama.chat.playground.explainer.TopKBars
+
+/**
+ * The headline tab. Step through Qwen3-0.6B token-by-token and inspect what
+ * happens inside: per-layer attention heatmaps, residual activations, and
+ * top-K next-token distribution.
+ *
+ * One-way flow for v1: the runtime's KV-cache state grows as the user
+ * advances; there is no in-app "reset" — restart the app to start over.
+ */
+@Composable
+fun ExplainerTab(
+    holder: QwenModelHolder,
+    state: QwenLoadingState,
+) {
+    var prompt by remember { mutableStateOf("The quick brown fox") }
+    var tokensSoFar by remember { mutableStateOf<IntArray>(intArrayOf()) }
+    var promptProcessed by remember { mutableStateOf(false) }
+    var snapshot by remember { mutableStateOf<StepSnapshot?>(null) }
+    var selectedBlock by remember { mutableStateOf(0) }
+    var selectedHead by remember { mutableStateOf(0) }
+    var working by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val scroll = rememberScrollState()
+
+    Column(
+        modifier = Modifier.fillMaxWidth().verticalScroll(scroll),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            "Transformer Explainer — what's happening inside Qwen3 as it generates one token at a time.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        OutlinedTextField(
+            value = prompt,
+            onValueChange = {
+                if (!promptProcessed) prompt = it
+            },
+            label = { Text(if (promptProcessed) "Prompt (locked once stepping starts)" else "Prompt") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !promptProcessed && !working,
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                enabled = state is QwenLoadingState.Ready && !working,
+                onClick = {
+                    val ready = state as? QwenLoadingState.Ready ?: return@Button
+                    working = true
+                    scope.launch {
+                        try {
+                            if (!promptProcessed) {
+                                // Initial run: feed all prompt tokens through.
+                                val promptTokens = ready.tokenizer.encode(prompt)
+                                var snap: StepSnapshot? = null
+                                var accum = IntArray(0)
+                                for (t in promptTokens) {
+                                    snap = holder.stepInstrumented(
+                                        tokenId = t,
+                                        priorTokens = accum,
+                                        temperature = 0f,
+                                    )
+                                    accum = accum + t
+                                }
+                                if (snap != null) {
+                                    snapshot = snap
+                                    tokensSoFar = snap.tokensSoFar
+                                    promptProcessed = true
+                                }
+                            } else {
+                                val last = tokensSoFar.last()
+                                val snap = holder.stepInstrumented(
+                                    tokenId = last,
+                                    priorTokens = tokensSoFar,
+                                    temperature = 0f,
+                                )
+                                snapshot = snap
+                                tokensSoFar = snap.tokensSoFar
+                            }
+                        } finally {
+                            working = false
+                        }
+                    }
+                },
+            ) {
+                Text(
+                    when {
+                        working -> "Running..."
+                        !promptProcessed -> "Run prompt"
+                        else -> "Step"
+                    }
+                )
+            }
+
+            if (snapshot != null) {
+                Text(
+                    "Step latency: ${snapshot!!.elapsedMillis} ms",
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.wrapContentHeight().padding(top = 12.dp),
+                )
+            }
+        }
+
+        TokenStrip(
+            tokensSoFar = tokensSoFar,
+            tokenizer = (state as? QwenLoadingState.Ready)?.tokenizer,
+        )
+
+        if (state is QwenLoadingState.Ready) {
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Column(modifier = Modifier.width(180.dp)) {
+                    ArchitectureDiagram(
+                        arch = state.architecture,
+                        selectedBlock = selectedBlock,
+                        onBlockSelected = { selectedBlock = it },
+                    )
+                }
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    val attentionForSelected = snapshot?.perLayerAttention?.firstOrNull {
+                        it.blockIndex == selectedBlock
+                    }
+                    AttentionHeatmap(
+                        capture = attentionForSelected,
+                        selectedHead = selectedHead,
+                        onHeadSelected = { selectedHead = it },
+                    )
+                    val residualForSelected = snapshot?.perLayerResidual?.firstOrNull {
+                        it.blockIndex == selectedBlock
+                    }
+                    ResidualBars(capture = residualForSelected)
+                    TopKBars(entries = snapshot?.topK.orEmpty())
+                }
+            }
+        } else {
+            Text("Waiting for model to load...", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun TokenStrip(
+    tokensSoFar: IntArray,
+    tokenizer: sk.ainet.apps.llm.Tokenizer?,
+) {
+    if (tokensSoFar.isEmpty() || tokenizer == null) return
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            tokensSoFar.takeLast(40).forEach { id ->
+                SuggestionChip(
+                    onClick = {},
+                    label = {
+                        Text(
+                            text = displayToken(tokenizer.decode(id)),
+                            fontFamily = FontFamily.Monospace,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun displayToken(s: String): String = when {
+    s.isEmpty() -> "∅"
+    s == "\n" -> "\\n"
+    s.isBlank() -> "·"
+    else -> s
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ModelLoadingPanel.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ModelLoadingPanel.kt
@@ -1,0 +1,53 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import sk.ainet.ui.components.LoadingIndicator
+
+/**
+ * In-tab placeholder shown while the model is being loaded. Reused by
+ * every inference tab so the model-load progress is visible no matter
+ * which tab the user lands on first.
+ */
+@Composable
+fun ModelLoadingPanel(state: QwenLoadingState, modifier: Modifier = Modifier) {
+    val phase = when (state) {
+        QwenLoadingState.Idle -> "Waiting to start..."
+        is QwenLoadingState.Loading -> state.phase
+        is QwenLoadingState.Failed -> "Failed: ${state.message}"
+        is QwenLoadingState.Ready -> "Ready."
+    }
+    val isError = state is QwenLoadingState.Failed
+    val isBusy = state is QwenLoadingState.Idle || state is QwenLoadingState.Loading
+
+    Column(
+        modifier = modifier.fillMaxWidth().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (isBusy) {
+            LoadingIndicator(size = 56.dp)
+        }
+        Text(
+            text = phase,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (isError) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (isBusy) {
+            Text(
+                text = "Loading once on app launch — every tab shares the same model.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenGenerateExt.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenGenerateExt.kt
@@ -1,5 +1,7 @@
 package sk.ainet.apps.kllama.chat.playground
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import sk.ainet.apps.llm.OptimizedLLMRuntime
 import sk.ainet.apps.llm.Tokenizer
 import sk.ainet.apps.llm.generate
@@ -10,6 +12,11 @@ import sk.ainet.lang.types.FP32
  * the `<|im_end|>` ChatML control token. Streams decoded text chunks via
  * [onText]. The buffer dance is so we can detect `<|im_end|>` across token
  * boundaries (it tokenizes as multiple pieces on Qwen3).
+ *
+ * Runs the inference loop on [Dispatchers.Default] so the UI thread stays
+ * responsive on JVM/Android/iOS. The [onText] callback is invoked on the
+ * Default dispatcher; Compose's mutableStateOf is safe to write from any
+ * thread.
  */
 suspend fun OptimizedLLMRuntime<FP32>.generateUntilImEnd(
     tokenizer: Tokenizer,
@@ -22,27 +29,29 @@ suspend fun OptimizedLLMRuntime<FP32>.generateUntilImEnd(
     val buffer = StringBuilder()
     var stopped = false
 
-    generate(prompt = promptTokens, steps = maxTokens, temperature = temperature) { id ->
-        if (stopped) return@generate
-        buffer.append(tokenizer.decode(id))
+    withContext(Dispatchers.Default) {
+        generate(prompt = promptTokens, steps = maxTokens, temperature = temperature) { id ->
+            if (stopped) return@generate
+            buffer.append(tokenizer.decode(id))
 
-        val idx = buffer.indexOf(stopMarker)
-        if (idx >= 0) {
-            if (idx > 0) onText(buffer.substring(0, idx))
-            buffer.clear()
-            stopped = true
-            return@generate
-        }
+            val idx = buffer.indexOf(stopMarker)
+            if (idx >= 0) {
+                if (idx > 0) onText(buffer.substring(0, idx))
+                buffer.clear()
+                stopped = true
+                return@generate
+            }
 
-        // Hold back tail equal to stopMarker length so a partial match
-        // doesn't leak into the UI before we confirm/deny it.
-        val safe = (buffer.length - stopMarker.length).coerceAtLeast(0)
-        if (safe > 0) {
-            val emitted = buffer.substring(0, safe)
-            onText(emitted)
-            val tail = buffer.substring(safe)
-            buffer.clear()
-            buffer.append(tail)
+            // Hold back tail equal to stopMarker length so a partial match
+            // doesn't leak into the UI before we confirm/deny it.
+            val safe = (buffer.length - stopMarker.length).coerceAtLeast(0)
+            if (safe > 0) {
+                val emitted = buffer.substring(0, safe)
+                onText(emitted)
+                val tail = buffer.substring(safe)
+                buffer.clear()
+                buffer.append(tail)
+            }
         }
     }
 

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenGenerateExt.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenGenerateExt.kt
@@ -1,0 +1,50 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.apps.llm.generate
+import sk.ainet.lang.types.FP32
+
+/**
+ * Generate up to [maxTokens] tokens, stopping early when the model emits
+ * the `<|im_end|>` ChatML control token. Streams decoded text chunks via
+ * [onText]. The buffer dance is so we can detect `<|im_end|>` across token
+ * boundaries (it tokenizes as multiple pieces on Qwen3).
+ */
+suspend fun OptimizedLLMRuntime<FP32>.generateUntilImEnd(
+    tokenizer: Tokenizer,
+    promptTokens: IntArray,
+    maxTokens: Int,
+    temperature: Float,
+    onText: (String) -> Unit,
+) {
+    val stopMarker = "<|im_end|>"
+    val buffer = StringBuilder()
+    var stopped = false
+
+    generate(prompt = promptTokens, steps = maxTokens, temperature = temperature) { id ->
+        if (stopped) return@generate
+        buffer.append(tokenizer.decode(id))
+
+        val idx = buffer.indexOf(stopMarker)
+        if (idx >= 0) {
+            if (idx > 0) onText(buffer.substring(0, idx))
+            buffer.clear()
+            stopped = true
+            return@generate
+        }
+
+        // Hold back tail equal to stopMarker length so a partial match
+        // doesn't leak into the UI before we confirm/deny it.
+        val safe = (buffer.length - stopMarker.length).coerceAtLeast(0)
+        if (safe > 0) {
+            val emitted = buffer.substring(0, safe)
+            onText(emitted)
+            val tail = buffer.substring(safe)
+            buffer.clear()
+            buffer.append(tail)
+        }
+    }
+
+    if (!stopped && buffer.isNotEmpty()) onText(buffer.toString())
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
@@ -1,0 +1,106 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.io.Buffer
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.apps.llm.generate
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.qwen.QwenNetworkLoader
+
+sealed interface QwenLoadingState {
+    data object Idle : QwenLoadingState
+    data class Loading(val phase: String) : QwenLoadingState
+    data class Ready(
+        val tokenizer: Tokenizer,
+        val runtime: OptimizedLLMRuntime<FP32>,
+        val loadMillis: Long,
+    ) : QwenLoadingState
+    data class Failed(val stage: String, val message: String) : QwenLoadingState
+}
+
+/**
+ * Single-instance holder for the loaded Qwen3-0.6B model. All five
+ * playground tabs share the one model — load once, use many times.
+ *
+ * Tokenizer is parsed first (fast, ~seconds) so the Tokenizer tab can
+ * be interactive while the model weights are still loading.
+ */
+class QwenModelHolder {
+    private val _state = MutableStateFlow<QwenLoadingState>(QwenLoadingState.Idle)
+    val state: StateFlow<QwenLoadingState> = _state.asStateFlow()
+
+    private val ctx = DirectCpuExecutionContext()
+
+    suspend fun load(bytes: ByteArray) {
+        if (_state.value is QwenLoadingState.Ready) return
+        val startMs = kotlin.time.TimeSource.Monotonic.markNow()
+
+        _state.value = QwenLoadingState.Loading("Reading tokenizer from GGUF metadata...")
+        val tokenizer = try {
+            val source = Buffer().apply { write(bytes) }
+            GGUFTokenizer.fromSource(source)
+        } catch (e: Throwable) {
+            _state.value = QwenLoadingState.Failed(
+                stage = "tokenizer",
+                message = "${e::class.simpleName}: ${e.message ?: "no message"}",
+            )
+            return
+        }
+
+        _state.value = QwenLoadingState.Loading("Loading 600M-parameter weights (this can take ~40s)...")
+        val runtime = try {
+            val sourceProvider = { Buffer().apply { write(bytes) } }
+            val model = QwenNetworkLoader
+                .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
+                .load<FP32, Float>(ctx)
+
+            OptimizedLLMRuntime(
+                model = model,
+                ctx = ctx,
+                mode = OptimizedLLMMode.DIRECT,
+                dtype = FP32::class,
+                bos = tokenizer.bosTokenId,
+            )
+        } catch (e: Throwable) {
+            _state.value = QwenLoadingState.Failed(
+                stage = "model-load",
+                message = "${e::class.simpleName}: ${e.message ?: "no message"}",
+            )
+            return
+        }
+
+        _state.value = QwenLoadingState.Ready(
+            tokenizer = tokenizer,
+            runtime = runtime,
+            loadMillis = startMs.elapsedNow().inWholeMilliseconds,
+        )
+    }
+
+    /**
+     * Stream a continuation given an already-tokenized prompt. Emits decoded
+     * text chunks via [onChunk]. Caller is responsible for prepending BOS,
+     * applying chat templates, etc.
+     */
+    suspend fun stream(
+        promptTokens: IntArray,
+        maxTokens: Int,
+        temperature: Float,
+        onChunk: (String) -> Unit,
+    ) {
+        val ready = _state.value as? QwenLoadingState.Ready ?: error("Model not loaded")
+        ready.runtime.generate(
+            prompt = promptTokens,
+            steps = maxTokens,
+            temperature = temperature,
+        ) { id ->
+            onChunk(ready.tokenizer.decode(id))
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
@@ -1,8 +1,10 @@
 package sk.ainet.apps.kllama.chat.playground
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 import kotlinx.io.Buffer
 import sk.ainet.apps.kllama.chat.playground.explainer.ArchitectureSummary
 import sk.ainet.apps.kllama.chat.playground.explainer.InstrumentedExecutionContext
@@ -50,8 +52,9 @@ class QwenModelHolder {
 
         _state.value = QwenLoadingState.Loading("Reading tokenizer from GGUF metadata...")
         val tokenizer = try {
-            val source = Buffer().apply { write(bytes) }
-            GGUFTokenizer.fromSource(source)
+            withContext(Dispatchers.Default) {
+                GGUFTokenizer.fromSource(Buffer().apply { write(bytes) })
+            }
         } catch (e: Throwable) {
             _state.value = QwenLoadingState.Failed(
                 stage = "tokenizer",
@@ -62,18 +65,20 @@ class QwenModelHolder {
 
         _state.value = QwenLoadingState.Loading("Loading 600M-parameter weights (this can take ~40s)...")
         val runtime = try {
-            val sourceProvider = { Buffer().apply { write(bytes) } }
-            val model = QwenNetworkLoader
-                .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
-                .load<FP32, Float>(ctx)
+            withContext(Dispatchers.Default) {
+                val sourceProvider = { Buffer().apply { write(bytes) } }
+                val model = QwenNetworkLoader
+                    .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
+                    .load<FP32, Float>(ctx)
 
-            OptimizedLLMRuntime(
-                model = model,
-                ctx = ctx,
-                mode = OptimizedLLMMode.DIRECT,
-                dtype = FP32::class,
-                bos = tokenizer.bosTokenId,
-            )
+                OptimizedLLMRuntime(
+                    model = model,
+                    ctx = ctx,
+                    mode = OptimizedLLMMode.DIRECT,
+                    dtype = FP32::class,
+                    bos = tokenizer.bosTokenId,
+                )
+            }
         } catch (e: Throwable) {
             _state.value = QwenLoadingState.Failed(
                 stage = "model-load",
@@ -102,11 +107,11 @@ class QwenModelHolder {
      * is responsible for resetting the runtime (or building a fresh one)
      * between explainer sessions.
      */
-    fun stepInstrumented(
+    suspend fun stepInstrumented(
         tokenId: Int,
         priorTokens: IntArray,
         temperature: Float,
-    ): StepSnapshot {
+    ): StepSnapshot = withContext(Dispatchers.Default) {
         val ready = _state.value as? QwenLoadingState.Ready ?: error("Model not loaded")
         instrumented.reset()
         instrumented.captureEnabled = true
@@ -126,7 +131,7 @@ class QwenModelHolder {
         }
         val topK = topKEntries(logitVec, k = 10, tokenizer = ready.tokenizer, temperature = temperature)
 
-        return StepSnapshot(
+        StepSnapshot(
             inputTokenId = tokenId,
             tokensSoFar = priorTokens + sampledId,
             sampledTokenId = sampledId,
@@ -242,12 +247,14 @@ class QwenModelHolder {
         onChunk: (String) -> Unit,
     ) {
         val ready = _state.value as? QwenLoadingState.Ready ?: error("Model not loaded")
-        ready.runtime.generate(
-            prompt = promptTokens,
-            steps = maxTokens,
-            temperature = temperature,
-        ) { id ->
-            onChunk(ready.tokenizer.decode(id))
+        withContext(Dispatchers.Default) {
+            ready.runtime.generate(
+                prompt = promptTokens,
+                steps = maxTokens,
+                temperature = temperature,
+            ) { id ->
+                onChunk(ready.tokenizer.decode(id))
+            }
         }
     }
 }

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
@@ -4,13 +4,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.io.Buffer
+import sk.ainet.apps.kllama.chat.playground.explainer.ArchitectureSummary
+import sk.ainet.apps.kllama.chat.playground.explainer.InstrumentedExecutionContext
+import sk.ainet.apps.kllama.chat.playground.explainer.StepSnapshot
+import sk.ainet.apps.kllama.chat.playground.explainer.TopKEntry
 import sk.ainet.apps.llm.OptimizedLLMMode
 import sk.ainet.apps.llm.OptimizedLLMRuntime
 import sk.ainet.apps.llm.Tokenizer
 import sk.ainet.apps.llm.generate
 import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
-import sk.ainet.context.DirectCpuExecutionContext
 import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.nn.topology.ModuleNode
 import sk.ainet.lang.types.FP32
 import sk.ainet.models.qwen.QwenNetworkLoader
 
@@ -20,6 +24,7 @@ sealed interface QwenLoadingState {
     data class Ready(
         val tokenizer: Tokenizer,
         val runtime: OptimizedLLMRuntime<FP32>,
+        val architecture: ArchitectureSummary,
         val loadMillis: Long,
     ) : QwenLoadingState
     data class Failed(val stage: String, val message: String) : QwenLoadingState
@@ -36,7 +41,8 @@ class QwenModelHolder {
     private val _state = MutableStateFlow<QwenLoadingState>(QwenLoadingState.Idle)
     val state: StateFlow<QwenLoadingState> = _state.asStateFlow()
 
-    private val ctx = DirectCpuExecutionContext()
+    private val instrumented = InstrumentedExecutionContext()
+    private val ctx = instrumented.ctx
 
     suspend fun load(bytes: ByteArray) {
         if (_state.value is QwenLoadingState.Ready) return
@@ -76,11 +82,152 @@ class QwenModelHolder {
             return
         }
 
+        val architecture = summarizeArchitecture(runtime)
+
         _state.value = QwenLoadingState.Ready(
             tokenizer = tokenizer,
             runtime = runtime,
+            architecture = architecture,
             loadMillis = startMs.elapsedNow().inWholeMilliseconds,
         )
+    }
+
+    /**
+     * Run one `runtime.forward` step under instrumentation. The hooks +
+     * observer in [instrumented] capture per-layer residuals and attention
+     * heatmaps, which are bundled into a [StepSnapshot] together with the
+     * sampled next token and a top-k of the logits.
+     *
+     * The runtime's internal position counter still advances; the caller
+     * is responsible for resetting the runtime (or building a fresh one)
+     * between explainer sessions.
+     */
+    fun stepInstrumented(
+        tokenId: Int,
+        priorTokens: IntArray,
+        temperature: Float,
+    ): StepSnapshot {
+        val ready = _state.value as? QwenLoadingState.Ready ?: error("Model not loaded")
+        instrumented.reset()
+        instrumented.captureEnabled = true
+        val startMs = kotlin.time.TimeSource.Monotonic.markNow()
+        val logits = try {
+            ready.runtime.forward(tokenId)
+        } finally {
+            instrumented.captureEnabled = false
+        }
+        val elapsed = startMs.elapsedNow().inWholeMilliseconds
+
+        val logitVec = logits.data.copyToFloatArray()
+        val sampledId = if (temperature <= 1e-6f) {
+            argmax(logitVec)
+        } else {
+            sampleSoftmax(logitVec, temperature)
+        }
+        val topK = topKEntries(logitVec, k = 10, tokenizer = ready.tokenizer, temperature = temperature)
+
+        return StepSnapshot(
+            inputTokenId = tokenId,
+            tokensSoFar = priorTokens + sampledId,
+            sampledTokenId = sampledId,
+            sampledTokenText = ready.tokenizer.decode(sampledId),
+            topK = topK,
+            perLayerAttention = instrumented.attentionCaptures(),
+            perLayerResidual = instrumented.residualCaptures(),
+            elapsedMillis = elapsed,
+        )
+    }
+
+    private fun summarizeArchitecture(runtime: OptimizedLLMRuntime<FP32>): ArchitectureSummary {
+        val blockNames = mutableListOf<String>()
+        walkModules(runtime.modelRoot()) { node ->
+            if (node.name.startsWith("blk.")) blockNames += node.name
+        }
+        return ArchitectureSummary(
+            numLayers = runtime.nLayers,
+            hiddenDim = runtime.dim,
+            vocabSize = runtime.vocabSize,
+            maxSeqLen = runtime.seqLen,
+            blockNames = blockNames.distinct().sortedBy { it.removePrefix("blk.").toIntOrNull() ?: 0 },
+        )
+    }
+
+    private fun walkModules(root: ModuleNode, visit: (ModuleNode) -> Unit) {
+        visit(root)
+        root.children.forEach { walkModules(it, visit) }
+    }
+
+    private fun OptimizedLLMRuntime<FP32>.modelRoot(): ModuleNode {
+        // OptimizedLLMRuntime keeps `model` private; reach in via reflection-free
+        // workaround: the module hierarchy is exposed indirectly through the
+        // runtime's public APIs (nLayers / dim / etc.), but for a name walk we
+        // need the actual root. Until upstream exposes it, fall back to a
+        // shallow synthetic node containing the block names we already know.
+        return SyntheticRoot(numLayers = this.nLayers)
+    }
+
+    private class SyntheticRoot(numLayers: Int) : ModuleNode {
+        override val id: String = "root"
+        override val name: String = "qwen3"
+        override var path: String? = null
+        override val children: List<ModuleNode> =
+            (0 until numLayers).map { idx -> SyntheticChild("blk.$idx") }
+        override val params: List<sk.ainet.lang.nn.topology.ModuleParameter<*, *>> = emptyList()
+    }
+
+    private class SyntheticChild(override val name: String) : ModuleNode {
+        override val id: String = name
+        override var path: String? = null
+        override val children: List<ModuleNode> = emptyList()
+        override val params: List<sk.ainet.lang.nn.topology.ModuleParameter<*, *>> = emptyList()
+    }
+
+    private fun argmax(values: FloatArray): Int {
+        var bestIdx = 0
+        var bestVal = values[0]
+        for (i in 1 until values.size) {
+            if (values[i] > bestVal) { bestVal = values[i]; bestIdx = i }
+        }
+        return bestIdx
+    }
+
+    private fun sampleSoftmax(values: FloatArray, temperature: Float): Int {
+        val probs = softmax(values, temperature)
+        val u = kotlin.random.Random.nextFloat()
+        var acc = 0f
+        for (i in probs.indices) {
+            acc += probs[i]
+            if (u <= acc) return i
+        }
+        return probs.size - 1
+    }
+
+    private fun softmax(values: FloatArray, temperature: Float): FloatArray {
+        val out = FloatArray(values.size)
+        var maxV = Float.NEGATIVE_INFINITY
+        for (v in values) if (v > maxV) maxV = v
+        var sum = 0f
+        for (i in values.indices) {
+            val e = kotlin.math.exp(((values[i] - maxV) / temperature).toDouble()).toFloat()
+            out[i] = e
+            sum += e
+        }
+        if (sum > 0f) for (i in out.indices) out[i] /= sum
+        return out
+    }
+
+    private fun topKEntries(
+        logits: FloatArray,
+        k: Int,
+        tokenizer: Tokenizer,
+        temperature: Float,
+    ): List<TopKEntry> {
+        val effectiveT = if (temperature <= 1e-6f) 1f else temperature
+        val probs = softmax(logits, effectiveT)
+        val indexed = probs.withIndex().sortedByDescending { it.value }.take(k)
+        return indexed.map { (idx, prob) ->
+            TopKEntry(id = idx, text = tokenizer.decode(idx), probability = prob)
+        }
     }
 
     /**

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenModelHolder.kt
@@ -63,21 +63,10 @@ class QwenModelHolder {
             return
         }
 
-        _state.value = QwenLoadingState.Loading("Loading 600M-parameter weights (this can take ~40s)...")
+        _state.value = QwenLoadingState.Loading("Loading 600M-parameter weights (Q4_0 packed; first call can take ~20-40s)...")
         val runtime = try {
             withContext(Dispatchers.Default) {
-                val sourceProvider = { Buffer().apply { write(bytes) } }
-                val model = QwenNetworkLoader
-                    .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
-                    .load<FP32, Float>(ctx)
-
-                OptimizedLLMRuntime(
-                    model = model,
-                    ctx = ctx,
-                    mode = OptimizedLLMMode.DIRECT,
-                    dtype = FP32::class,
-                    bos = tokenizer.bosTokenId,
-                )
+                buildQwenRuntime(ctx, bytes, tokenizer.bosTokenId)
             }
         } catch (e: Throwable) {
             _state.value = QwenLoadingState.Failed(

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -22,7 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kllamademo.composeapp.generated.resources.Res
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import sk.ainet.ui.components.LoadingIndicator
 
 private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q3_K_S.gguf"
 
@@ -38,7 +40,7 @@ fun QwenPlaygroundHost() {
 
     LaunchedEffect(Unit) {
         if (state is QwenLoadingState.Idle) {
-            val bytes = Res.readBytes(MODEL_RESOURCE_PATH)
+            val bytes = withContext(Dispatchers.Default) { Res.readBytes(MODEL_RESOURCE_PATH) }
             holder.load(bytes)
         }
     }
@@ -89,7 +91,7 @@ private fun Footer(state: QwenLoadingState) {
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         if (state is QwenLoadingState.Loading) {
-            CircularProgressIndicator(modifier = Modifier.padding(top = 4.dp))
+            LoadingIndicator(size = 36.dp, modifier = Modifier.padding(top = 4.dp))
         }
         Text(
             text = label,

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import sk.ainet.ui.components.LoadingIndicator
 
-private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q3_K_S.gguf"
+private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q4_0.gguf"
 
 /**
  * Top-level Qwen3-0.6B playground host. Owns the singleton [QwenModelHolder]

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
@@ -1,0 +1,102 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kllamademo.composeapp.generated.resources.Res
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q4_K_M.gguf"
+
+/**
+ * Top-level Qwen3-0.6B playground host. Owns the singleton [QwenModelHolder]
+ * and renders a TabRow with the playground demo modes.
+ */
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+fun QwenPlaygroundHost() {
+    val holder = remember { QwenModelHolder() }
+    val state by holder.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (state is QwenLoadingState.Idle) {
+            val bytes = Res.readBytes(MODEL_RESOURCE_PATH)
+            holder.load(bytes)
+        }
+    }
+
+    var selectedTab by remember { mutableStateOf(0) }
+    val tabs = listOf("Tokenizer", "Chat")
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(title) },
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            contentAlignment = Alignment.TopStart,
+        ) {
+            when (selectedTab) {
+                0 -> TokenizerTab(state)
+                1 -> ChatTab(state)
+            }
+        }
+
+        Footer(state)
+    }
+}
+
+@Composable
+private fun Footer(state: QwenLoadingState) {
+    val label = when (state) {
+        QwenLoadingState.Idle -> "Idle"
+        is QwenLoadingState.Loading -> state.phase
+        is QwenLoadingState.Ready -> "Ready — loaded in ${state.loadMillis} ms"
+        is QwenLoadingState.Failed -> "Failed at '${state.stage}': ${state.message}"
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        if (state is QwenLoadingState.Loading) {
+            CircularProgressIndicator(modifier = Modifier.padding(top = 4.dp))
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (state is QwenLoadingState.Failed) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = "Model: Qwen3-0.6B (Q4_K_M) — Apache 2.0 — Alibaba Cloud / Qwen team",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import kllamademo.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 
-private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q4_K_M.gguf"
+private const val MODEL_RESOURCE_PATH = "files/qwen3-0.6b-Q3_K_S.gguf"
 
 /**
  * Top-level Qwen3-0.6B playground host. Owns the singleton [QwenModelHolder]
@@ -44,7 +44,7 @@ fun QwenPlaygroundHost() {
     }
 
     var selectedTab by remember { mutableStateOf(0) }
-    val tabs = listOf("Tokenizer", "Chat", "Completion", "Translate", "Tool call")
+    val tabs = listOf("Visualize", "Tokenizer", "Chat", "Completion", "Translate", "Tool call")
 
     Column(modifier = Modifier.fillMaxSize()) {
         TabRow(selectedTabIndex = selectedTab) {
@@ -62,11 +62,12 @@ fun QwenPlaygroundHost() {
             contentAlignment = Alignment.TopStart,
         ) {
             when (selectedTab) {
-                0 -> TokenizerTab(state)
-                1 -> ChatTab(state)
-                2 -> CompletionTab(state)
-                3 -> TranslateTab(state)
-                4 -> ToolCallTab(state)
+                0 -> ExplainerTab(holder = holder, state = state)
+                1 -> TokenizerTab(state)
+                2 -> ChatTab(state)
+                3 -> CompletionTab(state)
+                4 -> TranslateTab(state)
+                5 -> ToolCallTab(state)
             }
         }
 
@@ -97,7 +98,7 @@ private fun Footer(state: QwenLoadingState) {
                     else MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Text(
-            text = "Model: Qwen3-0.6B (Q4_K_M) — Apache 2.0 — Alibaba Cloud / Qwen team",
+            text = "Model: Qwen3-0.6B (Q3_K_S, ~280 MB) — Apache 2.0 — Alibaba Cloud / Qwen team",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenPlaygroundHost.kt
@@ -44,7 +44,7 @@ fun QwenPlaygroundHost() {
     }
 
     var selectedTab by remember { mutableStateOf(0) }
-    val tabs = listOf("Tokenizer", "Chat")
+    val tabs = listOf("Tokenizer", "Chat", "Completion", "Translate", "Tool call")
 
     Column(modifier = Modifier.fillMaxSize()) {
         TabRow(selectedTabIndex = selectedTab) {
@@ -64,6 +64,9 @@ fun QwenPlaygroundHost() {
             when (selectedTab) {
                 0 -> TokenizerTab(state)
                 1 -> ChatTab(state)
+                2 -> CompletionTab(state)
+                3 -> TranslateTab(state)
+                4 -> ToolCallTab(state)
             }
         }
 

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.kt
@@ -1,0 +1,55 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import kotlinx.io.Buffer
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.qwen.QwenNetworkLoader
+
+/**
+ * Platform-split loader. On JVM we take the fast path:
+ * `JvmRandomAccessSource` over a temp file → `QuantPolicy.NATIVE_OPTIMIZED`
+ * → `DecoderGgufMemSegConverter` wraps Q4_0 / Q8_0 tensors as
+ * `Q4MemorySegmentTensorData` / `Q8MemorySegmentTensorData`. SIMD packed-
+ * byte matmul kernels dispatch on those markers at forward time, no
+ * per-call dequant.
+ *
+ * On wasmJs / iOS / Android we fall back to [buildQwenRuntimeFallback]:
+ * a sequential `kotlinx.io.Source` over the byte buffer +
+ * `QuantPolicy.DEQUANTIZE_TO_FP32`. Same correctness, much slower
+ * throughput — the SIMD/MemSeg kernels are JVM-only.
+ */
+internal expect suspend fun buildQwenRuntime(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32>
+
+/**
+ * Slow but multiplatform fallback used by wasmJs / iOS / Android.
+ * Dequantizes Q4_0 weights to FP32 during load (~1.5 GB working set for
+ * Qwen3-0.6B). Forward pass is then plain FP32 matmul, no SIMD packed
+ * kernels — perceptibly slow on a CPU. The JVM `actual` skips this and
+ * uses the packed-quant path; everywhere else this is the best we can do
+ * until upstream lands a wasmJs/Native SIMD backend.
+ */
+internal suspend fun buildQwenRuntimeFallback(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32> {
+    val sourceProvider = { Buffer().apply { write(bytes) } }
+    val model = QwenNetworkLoader
+        .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
+        .load<FP32, Float>(ctx)
+
+    return OptimizedLLMRuntime(
+        model = model,
+        ctx = ctx,
+        mode = OptimizedLLMMode.DIRECT,
+        dtype = FP32::class,
+        bos = bosTokenId,
+    )
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TokenizerTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TokenizerTab.kt
@@ -1,0 +1,88 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+/**
+ * No-inference tab: types text, shows how Qwen's BPE tokenizer breaks it
+ * into token IDs and their decoded text fragments.
+ */
+@Composable
+fun TokenizerTab(state: QwenLoadingState) {
+    var input by remember { mutableStateOf("Hello, world!") }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Text to tokenize") },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        when (state) {
+            QwenLoadingState.Idle, is QwenLoadingState.Loading -> {
+                Text("Waiting for tokenizer to load...", style = MaterialTheme.typography.bodyMedium)
+            }
+            is QwenLoadingState.Failed -> {
+                Text("Failed to load tokenizer: ${state.message}", color = MaterialTheme.colorScheme.error)
+            }
+            is QwenLoadingState.Ready -> {
+                val tokens by remember(input, state) {
+                    derivedStateOf { state.tokenizer.encode(input).toList() }
+                }
+                Text(
+                    text = "${tokens.size} tokens",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    items(tokens) { id ->
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            tonalElevation = 1.dp,
+                        ) {
+                            Text(
+                                text = "${id.toString().padStart(5)}  ${escape(state.tokenizer.decode(id))}",
+                                modifier = Modifier.padding(8.dp),
+                                fontFamily = FontFamily.Monospace,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun escape(s: String): String = buildString {
+    for (ch in s) {
+        when (ch) {
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            ' ' -> append('·')
+            else -> append(ch)
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ToolCallTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ToolCallTab.kt
@@ -2,6 +2,7 @@ package sk.ainet.apps.kllama.chat.playground
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
@@ -18,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import sk.ainet.ui.components.LoadingIndicator
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -48,6 +50,10 @@ fun ToolCallTab(state: QwenLoadingState) {
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        if (state !is QwenLoadingState.Ready) {
+            ModelLoadingPanel(state)
+            return@Column
+        }
         Text(
             "Experimental — Qwen3-0.6B is small and may not emit clean tool-call JSON without finetuning. This tab is a faithful demo of the round-trip even when the model misbehaves.",
             style = MaterialTheme.typography.bodySmall,
@@ -60,6 +66,10 @@ fun ToolCallTab(state: QwenLoadingState) {
             style = MaterialTheme.typography.bodyMedium,
         )
 
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+        ) {
         Button(
             enabled = state is QwenLoadingState.Ready && !running,
             onClick = {
@@ -110,6 +120,8 @@ fun ToolCallTab(state: QwenLoadingState) {
                 }
             },
         ) { Text(if (running) "Running..." else "Run the round-trip") }
+            if (running) LoadingIndicator(size = 24.dp)
+        }
 
         Labeled(label = "Model turn 1 (expected: JSON tool call)") {
             Text(

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ToolCallTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/ToolCallTab.kt
@@ -1,0 +1,149 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Tool-calling demo (experimental). Demonstrates the round-trip:
+ *
+ *   1. Model receives the user prompt + a tools section listing `get_current_time`.
+ *   2. We expect the model to emit a JSON tool call.
+ *   3. The host executes the tool locally (Clock.System.now()).
+ *   4. The tool result is fed back into a second model turn.
+ *   5. The model produces a natural-language answer.
+ *
+ * Qwen3 doesn't always reliably produce the right JSON without
+ * fine-tuning, so this tab also shows the *raw* model output so you
+ * can inspect what came back.
+ */
+@OptIn(ExperimentalTime::class)
+@Composable
+fun ToolCallTab(state: QwenLoadingState) {
+    val userPrompt = "What time is it right now?"
+    var modelTurn1 by remember { mutableStateOf("") }
+    var toolOutput by remember { mutableStateOf("") }
+    var modelTurn2 by remember { mutableStateOf("") }
+    var running by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            "Experimental — Qwen3-0.6B is small and may not emit clean tool-call JSON without finetuning. This tab is a faithful demo of the round-trip even when the model misbehaves.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Text("User prompt: \"$userPrompt\"", style = MaterialTheme.typography.bodyMedium)
+        Text(
+            "Available tool: get_current_time() → ISO timestamp",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        Button(
+            enabled = state is QwenLoadingState.Ready && !running,
+            onClick = {
+                val ready = state as? QwenLoadingState.Ready ?: return@Button
+                modelTurn1 = ""
+                toolOutput = ""
+                modelTurn2 = ""
+                running = true
+                scope.launch {
+                    try {
+                        // Turn 1: ask model to produce a tool call.
+                        val system =
+                            "You have access to one tool: " +
+                            "{\"name\":\"get_current_time\",\"description\":\"Returns the current time as an ISO-8601 timestamp.\",\"parameters\":{}}. " +
+                            "When the user asks a question that requires this tool, respond with ONLY a JSON object of the form " +
+                            "{\"tool\":\"get_current_time\",\"args\":{}}. Otherwise answer naturally."
+                        val turn1Prompt =
+                            "<|im_start|>system\n$system<|im_end|>\n" +
+                            "<|im_start|>user\n$userPrompt<|im_end|>\n" +
+                            "<|im_start|>assistant\n"
+                        ready.runtime.generateUntilImEnd(
+                            tokenizer = ready.tokenizer,
+                            promptTokens = ready.tokenizer.encode(turn1Prompt),
+                            maxTokens = 80,
+                            temperature = 0.1f,
+                            onText = { modelTurn1 += it },
+                        )
+
+                        // Execute the tool unconditionally (we know the answer the model wanted).
+                        toolOutput = "{\"iso\":\"${Clock.System.now()}\"}"  // wall clock
+
+                        // Turn 2: feed the tool result back, ask for natural-language answer.
+                        val turn2Prompt =
+                            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" +
+                            "<|im_start|>user\n$userPrompt<|im_end|>\n" +
+                            "<|im_start|>assistant\nI looked it up via get_current_time which returned $toolOutput. Now I will answer: " +
+                            ""
+                        ready.runtime.generateUntilImEnd(
+                            tokenizer = ready.tokenizer,
+                            promptTokens = ready.tokenizer.encode(turn2Prompt),
+                            maxTokens = 80,
+                            temperature = 0.5f,
+                            onText = { modelTurn2 += it },
+                        )
+                    } finally {
+                        running = false
+                    }
+                }
+            },
+        ) { Text(if (running) "Running..." else "Run the round-trip") }
+
+        Labeled(label = "Model turn 1 (expected: JSON tool call)") {
+            Text(
+                modelTurn1.ifEmpty { "(not run yet)" },
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Labeled(label = "Tool output (host-executed)") {
+            Text(
+                toolOutput.ifEmpty { "(not run yet)" },
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Labeled(label = "Model turn 2 (natural-language answer)") {
+            Text(
+                modelTurn2.ifEmpty { "(not run yet)" },
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Labeled(label: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            tonalElevation = 1.dp,
+        ) {
+            Column(modifier = Modifier.padding(8.dp)) { content() }
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TranslateTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TranslateTab.kt
@@ -1,0 +1,100 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+private enum class Direction(val label: String, val systemPrompt: String) {
+    EN_TO_ZH(
+        "English → Chinese",
+        "You are a professional translator. Translate the following English text to Chinese (Simplified). Output only the translation, no commentary.",
+    ),
+    ZH_TO_EN(
+        "Chinese → English",
+        "You are a professional translator. Translate the following Chinese text to English. Output only the translation, no commentary.",
+    ),
+}
+
+/**
+ * Translation tab: showcases Qwen3's bilingual English ↔ Chinese strength.
+ * Uses the ChatML template internally; the system prompt instructs the model
+ * to emit only the translation.
+ */
+@Composable
+fun TranslateTab(state: QwenLoadingState) {
+    var direction by remember { mutableStateOf(Direction.EN_TO_ZH) }
+    var input by remember { mutableStateOf("Hello, how are you today?") }
+    var output by remember { mutableStateOf("") }
+    var generating by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Direction.entries.forEach { d ->
+                Button(
+                    enabled = !generating && d != direction,
+                    onClick = { direction = d },
+                ) { Text(d.label) }
+            }
+        }
+
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Text to translate") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !generating,
+        )
+
+        Button(
+            enabled = state is QwenLoadingState.Ready && !generating,
+            onClick = {
+                val ready = state as? QwenLoadingState.Ready ?: return@Button
+                output = ""
+                generating = true
+                scope.launch {
+                    try {
+                        val templated =
+                            "<|im_start|>system\n${direction.systemPrompt}<|im_end|>\n" +
+                            "<|im_start|>user\n$input<|im_end|>\n" +
+                            "<|im_start|>assistant\n"
+                        val tokens = ready.tokenizer.encode(templated)
+                        ready.runtime.generateUntilImEnd(
+                            tokenizer = ready.tokenizer,
+                            promptTokens = tokens,
+                            maxTokens = 256,
+                            temperature = 0.3f,
+                            onText = { chunk -> output += chunk },
+                        )
+                    } finally {
+                        generating = false
+                    }
+                }
+            },
+        ) { Text(if (generating) "Translating..." else "Translate") }
+
+        Text(
+            text = if (output.isEmpty() && !generating) "(translation will appear here)" else output,
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TranslateTab.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/TranslateTab.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import sk.ainet.ui.components.LoadingIndicator
 
 private enum class Direction(val label: String, val systemPrompt: String) {
     EN_TO_ZH(
@@ -47,6 +49,10 @@ fun TranslateTab(state: QwenLoadingState) {
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        if (state !is QwenLoadingState.Ready) {
+            ModelLoadingPanel(state)
+            return@Column
+        }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Direction.entries.forEach { d ->
                 Button(
@@ -64,6 +70,10 @@ fun TranslateTab(state: QwenLoadingState) {
             enabled = !generating,
         )
 
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
         Button(
             enabled = state is QwenLoadingState.Ready && !generating,
             onClick = {
@@ -90,6 +100,8 @@ fun TranslateTab(state: QwenLoadingState) {
                 }
             },
         ) { Text(if (generating) "Translating..." else "Translate") }
+            if (generating) LoadingIndicator(size = 24.dp)
+        }
 
         Text(
             text = if (output.isEmpty() && !generating) "(translation will appear here)" else output,

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/ArchitectureDiagram.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/ArchitectureDiagram.kt
@@ -1,0 +1,110 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+/**
+ * Vertical block stack showing the Qwen3 decoder architecture.
+ * Click a block to select it for the heatmap + residual panels.
+ *
+ *      ┌──────────────┐
+ *      │ token_embed  │
+ *      └──────────────┘
+ *             │
+ *      ┌──────────────┐
+ *      │   blk.0      │  ← selected has a thick stroke
+ *      └──────────────┘
+ *             │
+ *           ... N blocks
+ *             │
+ *      ┌──────────────┐
+ *      │  output (lm) │
+ *      └──────────────┘
+ */
+@Composable
+fun ArchitectureDiagram(
+    arch: ArchitectureSummary,
+    selectedBlock: Int,
+    onBlockSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            "Qwen3 — ${arch.numLayers} decoder blocks · dim=${arch.hiddenDim} · vocab=${arch.vocabSize}",
+            style = MaterialTheme.typography.labelMedium,
+        )
+        val rowHeightDp = 22.dp
+        // Token embed + N blocks + output = (N+2) rows.
+        val totalRows = arch.numLayers + 2
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(rowHeightDp * totalRows)
+                .pointerInput(arch.numLayers) {
+                    detectTapGestures { offset ->
+                        val rowH = size.height / totalRows
+                        val rowIdx = (offset.y / rowH).toInt()
+                        // row 0 = token_embed, rows [1..N] = blocks, row N+1 = output
+                        val blockIdx = rowIdx - 1
+                        if (blockIdx in 0 until arch.numLayers) onBlockSelected(blockIdx)
+                    }
+                },
+        ) {
+            val rowH = size.height / totalRows
+            val boxW = size.width * 0.6f
+            val boxX = (size.width - boxW) / 2
+
+            fun drawRow(row: Int, label: String, selected: Boolean, isBlock: Boolean) {
+                val color = when {
+                    selected -> Color(0xFFFFE082)
+                    isBlock -> Color(0xFFB3E5FC)
+                    else -> Color(0xFFCFD8DC)
+                }
+                drawRect(
+                    color = color,
+                    topLeft = Offset(boxX, row * rowH + 2f),
+                    size = Size(boxW, rowH - 4f),
+                )
+                drawRect(
+                    color = if (selected) Color(0xFFFF8F00) else Color(0xFF455A64),
+                    topLeft = Offset(boxX, row * rowH + 2f),
+                    size = Size(boxW, rowH - 4f),
+                    style = Stroke(width = if (selected) 2.5f else 1f),
+                )
+                // small "rail" line between rows
+                if (row < totalRows - 1) {
+                    drawLine(
+                        color = Color(0xFF607D8B),
+                        start = Offset(size.width / 2, row * rowH + rowH - 2f),
+                        end = Offset(size.width / 2, (row + 1) * rowH + 2f),
+                        strokeWidth = 1.5f,
+                    )
+                }
+            }
+
+            drawRow(0, "token_embed", selected = false, isBlock = false)
+            for (i in 0 until arch.numLayers) {
+                drawRow(i + 1, "blk.$i", selected = i == selectedBlock, isBlock = true)
+            }
+            drawRow(arch.numLayers + 1, "output", selected = false, isBlock = false)
+        }
+        Text(
+            "Selected: blk.$selectedBlock",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/AttentionHeatmap.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/AttentionHeatmap.kt
@@ -1,0 +1,109 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Heatmap of one attention head's `seqLen × seqLen` post-softmax weights.
+ * Cell color goes from dark blue (≈0) to bright yellow (≈max).
+ */
+@Composable
+fun AttentionHeatmap(
+    capture: AttentionCapture?,
+    selectedHead: Int,
+    onHeadSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (capture == null) {
+            Text(
+                "Attention heatmap is not available for this layer. The SDPA kernel may have fused the softmax — in that case the observer does not see a discrete softmax op.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@Column
+        }
+
+        Text(
+            "Attention · blk.${capture.blockIndex} · ${capture.heads} heads · seqLen=${capture.seqLen}",
+            style = MaterialTheme.typography.labelMedium,
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            for (h in 0 until capture.heads) {
+                SuggestionChip(
+                    onClick = { onHeadSelected(h) },
+                    label = { Text("h$h") },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = if (h == selectedHead) MaterialTheme.colorScheme.primaryContainer
+                                         else MaterialTheme.colorScheme.surfaceVariant,
+                    ),
+                )
+            }
+        }
+
+        Canvas(
+            modifier = Modifier.fillMaxWidth().aspectRatio(1f),
+        ) {
+            val n = capture.seqLen
+            val cell = size.width / n
+            val maxV = headMax(capture, selectedHead)
+
+            for (r in 0 until n) {
+                for (c in 0 until n) {
+                    val v = headValue(capture, selectedHead, r, c)
+                    val norm = if (maxV > 0f) v / maxV else 0f
+                    drawRect(
+                        color = colorFor(norm),
+                        topLeft = Offset(c * cell, r * cell),
+                        size = Size(cell, cell),
+                    )
+                }
+            }
+        }
+        Text(
+            "Rows = query position, cols = key position. Brighter = higher attention.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun headValue(c: AttentionCapture, head: Int, r: Int, col: Int): Float {
+    val n = c.seqLen
+    val perHead = n * n
+    val headOffset = head * perHead
+    return c.values[headOffset + r * n + col]
+}
+
+private fun headMax(c: AttentionCapture, head: Int): Float {
+    val n = c.seqLen
+    val perHead = n * n
+    val headOffset = head * perHead
+    var m = 0f
+    for (i in headOffset until headOffset + perHead) if (c.values[i] > m) m = c.values[i]
+    return m
+}
+
+private fun colorFor(norm: Float): Color {
+    val v = norm.coerceIn(0f, 1f)
+    // viridis-ish: dark blue -> teal -> green -> yellow
+    val r = (v * v).coerceIn(0f, 1f)
+    val g = v.coerceIn(0f, 1f)
+    val b = (1f - v).coerceIn(0f, 1f) * 0.7f + 0.2f
+    return Color(red = r, green = g, blue = b, alpha = 1f)
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/InstrumentedExecutionContext.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/InstrumentedExecutionContext.kt
@@ -1,0 +1,139 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.context.ExecutionObserver
+import sk.ainet.lang.nn.hooks.ForwardHooks
+import sk.ainet.lang.nn.topology.ModuleNode
+import sk.ainet.lang.tensor.Tensor
+
+/**
+ * Wraps a [DirectCpuExecutionContext] with [ForwardHooks] + [ExecutionObserver]
+ * capture. Used by the Transformer Explainer to peek inside the forward pass
+ * one token at a time.
+ *
+ * Usage:
+ * ```kotlin
+ * val instr = InstrumentedExecutionContext()
+ * val runtime = OptimizedLLMRuntime(model, instr.ctx, ..., bos = ...)
+ *
+ * instr.reset()
+ * runtime.forward(tokenId)
+ * val attentions = instr.attentionCaptures()
+ * val residuals = instr.residualCaptures()
+ * ```
+ *
+ * - **Residuals** are captured via [ForwardHooks.onForwardEnd] when the module
+ *   name matches `blk.N`. The hook receives the block's output tensor; we
+ *   downsample to [MAX_RESIDUAL_BARS] floats.
+ * - **Attentions** are captured via [ExecutionObserver.onOpEnd] when the op is
+ *   `softmax`. The Qwen attention path emits per-block softmax with shape
+ *   `[batch, heads, seqQ, seqKV]`. We snapshot every one and keep them in
+ *   order — that order corresponds to layer order in DIRECT mode.
+ *
+ * If the SDPA kernel fuses the softmax (no discrete op visible to the
+ * observer), `attentionCaptures()` will be empty and the UI surfaces a
+ * "fused SDPA kernel" notice instead of the heatmap.
+ */
+class InstrumentedExecutionContext {
+
+    /**
+     * When false (default), hooks and observer short-circuit immediately.
+     * Set true around `runtime.forward(...)` only when the explainer needs
+     * the snapshot — that way the other playground tabs don't pay the
+     * per-block copy overhead during regular chat / completion.
+     */
+    var captureEnabled: Boolean = false
+
+    private val hooks = CapturingForwardHooks(::captureEnabled)
+    private val observer = CapturingExecutionObserver(::captureEnabled)
+
+    val ctx: ExecutionContext = DirectCpuExecutionContext(_hooks = hooks)
+
+    init {
+        ctx.registerObserver(observer)
+    }
+
+    fun reset() {
+        hooks.reset()
+        observer.reset()
+    }
+
+    fun residualCaptures(): List<ResidualCapture> = hooks.residuals.toList()
+    fun attentionCaptures(): List<AttentionCapture> = observer.attentions.toList()
+}
+
+private class CapturingForwardHooks(private val enabled: () -> Boolean) : ForwardHooks {
+    val residuals: MutableList<ResidualCapture> = mutableListOf()
+
+    fun reset() = residuals.clear()
+
+    override fun onForwardBegin(module: ModuleNode, input: Any) = Unit
+
+    override fun onForwardEnd(module: ModuleNode, input: Any, output: Any) {
+        if (!enabled()) return
+        val name = module.name
+        // The decoder DSL emits per-block names like "blk.0", "blk.1", ...
+        if (!name.startsWith("blk.")) return
+        val idx = name.removePrefix("blk.").toIntOrNull() ?: return
+        val tensor = output as? Tensor<*, *> ?: return
+        val flat = tensor.data.copyToFloatArray()
+        val dim = flat.size
+        val downsampled = downsample(flat, MAX_RESIDUAL_BARS)
+        residuals += ResidualCapture(
+            blockIndex = idx,
+            originalDim = dim,
+            downsampledValues = downsampled,
+        )
+    }
+
+    private fun downsample(src: FloatArray, target: Int): FloatArray {
+        if (src.size <= target) return src.copyOf()
+        // Bucket the source into `target` slots and take the slot mean.
+        val out = FloatArray(target)
+        val ratio = src.size.toDouble() / target.toDouble()
+        for (i in 0 until target) {
+            val start = (i * ratio).toInt()
+            val end = ((i + 1) * ratio).toInt().coerceAtMost(src.size)
+            var sum = 0f
+            var n = 0
+            for (j in start until end) {
+                sum += src[j]
+                n++
+            }
+            out[i] = if (n > 0) sum / n else 0f
+        }
+        return out
+    }
+}
+
+private class CapturingExecutionObserver(private val enabled: () -> Boolean) : ExecutionObserver {
+    val attentions: MutableList<AttentionCapture> = mutableListOf()
+    private var nextBlockIndex = 0
+
+    fun reset() {
+        attentions.clear()
+        nextBlockIndex = 0
+    }
+
+    override fun onOpEnd(context: ExecutionContext, opName: String, result: Any?) {
+        if (!enabled()) return
+        if (opName != "softmax") return
+        val tensor = result as? Tensor<*, *> ?: return
+        // Expected shape from MultiHeadAttention: [batch, heads, seqQ, seqKV].
+        // Drop attention heatmaps with other ranks (rare softmax callsites).
+        val dims = tensor.shape.dimensions
+        if (dims.size != 4) return
+        val heads = dims[1]
+        val seqQ = dims[2]
+        val seqKV = dims[3]
+        if (seqQ != seqKV) return
+        val flat = tensor.data.copyToFloatArray()
+        attentions += AttentionCapture(
+            blockIndex = nextBlockIndex++,
+            heads = heads,
+            seqLen = seqQ,
+            values = flat,
+        )
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/ResidualBars.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/ResidualBars.kt
@@ -1,0 +1,66 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+
+/**
+ * Bar chart of the residual stream values for the selected block, downsampled
+ * to [MAX_RESIDUAL_BARS] buckets. Negative values dip below center, positive
+ * rise above.
+ */
+@Composable
+fun ResidualBars(capture: ResidualCapture?, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (capture == null) {
+            Text(
+                "Residual stream for the selected block is not captured yet — run a Step first.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@Column
+        }
+        Text(
+            "Residual · blk.${capture.blockIndex} · dim=${capture.originalDim} (downsampled to ${capture.downsampledValues.size} bars)",
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Canvas(modifier = Modifier.fillMaxWidth().height(120.dp)) {
+            val values = capture.downsampledValues
+            val maxAbs = values.maxOfOrNull { abs(it) } ?: 1f
+            val safeMax = if (maxAbs == 0f) 1f else maxAbs
+            val barW = size.width / values.size
+            val midY = size.height / 2
+
+            // axis
+            drawLine(
+                color = Color(0xFFB0BEC5),
+                start = Offset(0f, midY),
+                end = Offset(size.width, midY),
+                strokeWidth = 1f,
+            )
+
+            for (i in values.indices) {
+                val v = values[i] / safeMax
+                val barH = (v.coerceIn(-1f, 1f)) * (size.height / 2)
+                val x = i * barW
+                val y0 = if (barH >= 0f) midY - barH else midY
+                val h = abs(barH)
+                drawRect(
+                    color = if (barH >= 0f) Color(0xFF1976D2) else Color(0xFFE53935),
+                    topLeft = Offset(x + 0.5f, y0),
+                    size = Size((barW - 1f).coerceAtLeast(1f), h),
+                )
+            }
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/StepSnapshot.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/StepSnapshot.kt
@@ -1,0 +1,85 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+/**
+ * Architecture description captured once after the model is loaded.
+ * Feeds the static "block stack" visualization in [ArchitectureDiagram].
+ */
+data class ArchitectureSummary(
+    val numLayers: Int,
+    val hiddenDim: Int,
+    val vocabSize: Int,
+    val maxSeqLen: Int,
+    val blockNames: List<String>,
+)
+
+/**
+ * Captures one attention layer's post-softmax probabilities.
+ * Stored flat (`heads * seqLen * seqLen`) so it can be rendered as
+ * a `heads`-stack of `seqLen × seqLen` heatmaps.
+ */
+data class AttentionCapture(
+    val blockIndex: Int,
+    val heads: Int,
+    val seqLen: Int,
+    val values: FloatArray,
+) {
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is AttentionCapture &&
+                blockIndex == other.blockIndex &&
+                heads == other.heads &&
+                seqLen == other.seqLen &&
+                values.contentEquals(other.values))
+
+    override fun hashCode(): Int {
+        var r = blockIndex
+        r = 31 * r + heads
+        r = 31 * r + seqLen
+        r = 31 * r + values.contentHashCode()
+        return r
+    }
+}
+
+/**
+ * Captures the residual stream after a transformer block. The values are
+ * already downsampled to at most [MAX_RESIDUAL_BARS] entries for rendering.
+ */
+data class ResidualCapture(
+    val blockIndex: Int,
+    val originalDim: Int,
+    val downsampledValues: FloatArray,
+) {
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is ResidualCapture &&
+                blockIndex == other.blockIndex &&
+                originalDim == other.originalDim &&
+                downsampledValues.contentEquals(other.downsampledValues))
+
+    override fun hashCode(): Int {
+        var r = blockIndex
+        r = 31 * r + originalDim
+        r = 31 * r + downsampledValues.contentHashCode()
+        return r
+    }
+}
+
+/** Top candidate next token: (id, decoded text, softmax probability). */
+data class TopKEntry(val id: Int, val text: String, val probability: Float)
+
+/**
+ * Everything captured during one `runtime.forward(tokenId)` call. Read by the
+ * UI after the forward call returns.
+ */
+class StepSnapshot(
+    val inputTokenId: Int,
+    val tokensSoFar: IntArray,
+    val sampledTokenId: Int,
+    val sampledTokenText: String,
+    val topK: List<TopKEntry>,
+    val perLayerAttention: List<AttentionCapture>,
+    val perLayerResidual: List<ResidualCapture>,
+    val elapsedMillis: Long,
+)
+
+internal const val MAX_RESIDUAL_BARS = 64

--- a/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/TopKBars.kt
+++ b/KllamaDemo/composeApp/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/playground/explainer/TopKBars.kt
@@ -1,0 +1,71 @@
+package sk.ainet.apps.kllama.chat.playground.explainer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+/**
+ * Top-K candidate next tokens as horizontal probability bars.
+ */
+@Composable
+fun TopKBars(entries: List<TopKEntry>, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            "Top-${entries.size} next-token candidates",
+            style = MaterialTheme.typography.labelMedium,
+        )
+        if (entries.isEmpty()) {
+            Text("(no candidates — run a Step first)", style = MaterialTheme.typography.bodySmall)
+            return@Column
+        }
+        val maxProb = entries.first().probability.coerceAtLeast(1e-6f)
+        entries.forEach { entry ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = escapeForDisplay(entry.text).padEnd(14).take(14),
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.width(130.dp),
+                )
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier
+                        .height(18.dp)
+                        .fillMaxWidth(entry.probability / maxProb),
+                ) {}
+                Text(
+                    text = " ${(entry.probability * 100f).toInt()}%",
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(start = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+private fun escapeForDisplay(s: String): String = buildString {
+    for (ch in s) {
+        when (ch) {
+            '\n' -> append("\\n")
+            '\t' -> append("\\t")
+            ' ' -> append('·')
+            else -> append(ch)
+        }
+    }
+}

--- a/KllamaDemo/composeApp/src/iosMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.ios.kt
+++ b/KllamaDemo/composeApp/src/iosMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.ios.kt
@@ -1,0 +1,11 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.types.FP32
+
+internal actual suspend fun buildQwenRuntime(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32> = buildQwenRuntimeFallback(ctx, bytes, bosTokenId)

--- a/KllamaDemo/composeApp/src/jvmMain/kotlin/sk/ainet/apps/kllama/chat/main.kt
+++ b/KllamaDemo/composeApp/src/jvmMain/kotlin/sk/ainet/apps/kllama/chat/main.kt
@@ -24,7 +24,7 @@ fun main() = application {
 
     Window(
         onCloseRequest = ::exitApplication,
-        title = "KLlama Chat - Offline LLM",
+        title = "Transformer Explainer — Qwen3-0.6B on SKaiNET",
         state = rememberWindowState(size = DpSize(1024.dp, 768.dp))
     ) {
         App()

--- a/KllamaDemo/composeApp/src/jvmMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.jvm.kt
+++ b/KllamaDemo/composeApp/src/jvmMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.jvm.kt
@@ -1,0 +1,67 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import java.lang.foreign.Arena
+import java.nio.file.Files
+import java.nio.file.Path
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.llama.DecoderGgufMemSegConverter
+import sk.ainet.models.llama.DecoderGgufWeightLoader
+import sk.ainet.models.qwen.QwenNetworkLoader
+
+private val QWEN_ARCHS = setOf("qwen2", "qwen3", "qwen35")
+
+internal actual suspend fun buildQwenRuntime(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32> {
+    // DecoderGgufWeightLoader + DecoderGgufMemSegConverter both need
+    // random-access reads, but we got our bytes via Res.readBytes() from
+    // Compose Resources — an in-memory ByteArray. Stage it to a temp file
+    // so JvmRandomAccessSource (which uses FileChannel) can serve it.
+    // The temp file is reused across the loader's metadata + tensor passes,
+    // then deleted on JVM exit.
+    val tempFile: Path = stageBytesToTempFile(bytes)
+
+    val loader = DecoderGgufWeightLoader(
+        randomAccessProvider = { JvmRandomAccessSource.open(tempFile.toString()) },
+        quantPolicy = QuantPolicy.NATIVE_OPTIMIZED,
+        acceptedArchitectures = QWEN_ARCHS,
+    )
+
+    val rawWeights = loader.loadToMapStreaming<FP32, Float>(ctx)
+
+    // Wrap Q4_0 / Q8_0 tensors as Q4/Q8 MemorySegmentTensorData. Embedded
+    // K-quants (Q4_K, Q5_K, Q6_K) and token_embd are dequantized to FP32 by
+    // the converter, but matmul-bound layers stay packed.
+    val convertedWeights = if (rawWeights.quantTypes.isNotEmpty()) {
+        val arena = Arena.ofShared()
+        DecoderGgufMemSegConverter.convert(rawWeights, ctx, arena)
+    } else {
+        rawWeights
+    }
+
+    val model = QwenNetworkLoader.fromWeights(convertedWeights)
+    return OptimizedLLMRuntime(
+        model = model,
+        ctx = ctx,
+        mode = OptimizedLLMMode.DIRECT,
+        dtype = FP32::class,
+        bos = convertedWeights.metadata.bosTokenId.takeIf { it >= 0 } ?: bosTokenId,
+    )
+}
+
+private fun stageBytesToTempFile(bytes: ByteArray): Path {
+    // createTempFile already creates an empty file; Files.write will
+    // overwrite it. deleteOnExit removes it at JVM shutdown so we don't
+    // accumulate 380 MB temp files across launches.
+    val tempFile = Files.createTempFile("kllamademo-qwen-", ".gguf")
+    Files.write(tempFile, bytes)
+    tempFile.toFile().deleteOnExit()
+    return tempFile
+}

--- a/KllamaDemo/composeApp/src/webMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.web.kt
+++ b/KllamaDemo/composeApp/src/webMain/kotlin/sk/ainet/apps/kllama/chat/playground/QwenRuntimeBuilder.web.kt
@@ -1,0 +1,11 @@
+package sk.ainet.apps.kllama.chat.playground
+
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.types.FP32
+
+internal actual suspend fun buildQwenRuntime(
+    ctx: ExecutionContext,
+    bytes: ByteArray,
+    bosTokenId: Int,
+): OptimizedLLMRuntime<FP32> = buildQwenRuntimeFallback(ctx, bytes, bosTokenId)

--- a/KllamaDemo/gradle/libs.versions.toml
+++ b/KllamaDemo/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ skainet-io-gguf = { module = "sk.ainet.core:skainet-io-gguf", version.ref = "ska
 
 # SKaiNET-transformers (LLM inference, runtime, agent)
 skainet-inference-llama = { module = "sk.ainet.transformers:skainet-transformers-inference-llama", version.ref = "skainet" }
+skainet-inference-qwen = { module = "sk.ainet.transformers:skainet-transformers-inference-qwen", version.ref = "skainet" }
 skainet-kllama = { module = "sk.ainet.transformers:skainet-transformers-runtime-kllama", version.ref = "skainet" }
 skainet-kllama-agents = { module = "sk.ainet.transformers:skainet-transformers-agent", version.ref = "skainet" }
 skainet-llm = { module = "sk.ainet.transformers:skainet-transformers-core", version.ref = "skainet" }

--- a/KllamaDemo/scripts/fetch-qwen-model.sh
+++ b/KllamaDemo/scripts/fetch-qwen-model.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fetch the Qwen3-0.6B GGUF (Q4_K_M, ~400 MB) into the composeApp's
+# Fetch the Qwen3-0.6B GGUF (Q4_0, ~380 MB) into the composeApp's
 # commonMain composeResources so the bundled wasmJs / desktop / Android / iOS
-# artifacts all carry the model. The destination is .gitignore'd via the
-# top-level *.gguf rule.
+# artifacts all carry the model. Q4_0 is the SIMD-friendly packed quant —
+# DecoderGgufMemSegConverter wraps these tensors as Q4MemorySegmentTensorData
+# so the CPU matmul stays in packed-byte form (4-bit weights), giving a
+# much faster forward pass than the heavier K-quants which fully dequantize
+# to FP32. The destination is .gitignore'd via the top-level *.gguf rule.
 
-MODEL_URL="https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q3_K_S.gguf"
+MODEL_URL="https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_0.gguf"
 DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/composeApp/src/commonMain/composeResources/files"
-DEST_FILE="$DEST_DIR/qwen3-0.6b-Q3_K_S.gguf"
-MIN_SIZE_BYTES=$((200 * 1024 * 1024))   # sanity floor: 200 MB (Q3_K_S is ~280 MB)
+DEST_FILE="$DEST_DIR/qwen3-0.6b-Q4_0.gguf"
+MIN_SIZE_BYTES=$((300 * 1024 * 1024))   # sanity floor: 300 MB (Q4_0 is ~380 MB)
 
 mkdir -p "$DEST_DIR"
 
@@ -23,7 +26,7 @@ if [[ -f "$DEST_FILE" ]]; then
     rm -f "$DEST_FILE"
 fi
 
-echo "Fetching Qwen3-0.6B-Q3_K_S.gguf (~280 MB) from Hugging Face..."
+echo "Fetching Qwen3-0.6B-Q4_0.gguf (~380 MB, packed SIMD-friendly quant) from Hugging Face..."
 curl -L --fail --progress-bar -o "$DEST_FILE" "$MODEL_URL"
 
 size=$(stat -f%z "$DEST_FILE" 2>/dev/null || stat -c%s "$DEST_FILE")

--- a/KllamaDemo/scripts/fetch-qwen-model.sh
+++ b/KllamaDemo/scripts/fetch-qwen-model.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 # artifacts all carry the model. The destination is .gitignore'd via the
 # top-level *.gguf rule.
 
-MODEL_URL="https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf"
+MODEL_URL="https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q3_K_S.gguf"
 DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/composeApp/src/commonMain/composeResources/files"
-DEST_FILE="$DEST_DIR/qwen3-0.6b-Q4_K_M.gguf"
-MIN_SIZE_BYTES=$((300 * 1024 * 1024))   # sanity floor: 300 MB
+DEST_FILE="$DEST_DIR/qwen3-0.6b-Q3_K_S.gguf"
+MIN_SIZE_BYTES=$((200 * 1024 * 1024))   # sanity floor: 200 MB (Q3_K_S is ~280 MB)
 
 mkdir -p "$DEST_DIR"
 
@@ -23,7 +23,7 @@ if [[ -f "$DEST_FILE" ]]; then
     rm -f "$DEST_FILE"
 fi
 
-echo "Fetching Qwen3-0.6B-Q4_K_M.gguf (~400 MB) from Hugging Face..."
+echo "Fetching Qwen3-0.6B-Q3_K_S.gguf (~280 MB) from Hugging Face..."
 curl -L --fail --progress-bar -o "$DEST_FILE" "$MODEL_URL"
 
 size=$(stat -f%z "$DEST_FILE" 2>/dev/null || stat -c%s "$DEST_FILE")

--- a/KllamaDemo/scripts/fetch-qwen-model.sh
+++ b/KllamaDemo/scripts/fetch-qwen-model.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the Qwen3-0.6B GGUF (Q4_K_M, ~400 MB) into the composeApp's
+# commonMain composeResources so the bundled wasmJs / desktop / Android / iOS
+# artifacts all carry the model. The destination is .gitignore'd via the
+# top-level *.gguf rule.
+
+MODEL_URL="https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf"
+DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/composeApp/src/commonMain/composeResources/files"
+DEST_FILE="$DEST_DIR/qwen3-0.6b-Q4_K_M.gguf"
+MIN_SIZE_BYTES=$((300 * 1024 * 1024))   # sanity floor: 300 MB
+
+mkdir -p "$DEST_DIR"
+
+if [[ -f "$DEST_FILE" ]]; then
+    size=$(stat -f%z "$DEST_FILE" 2>/dev/null || stat -c%s "$DEST_FILE")
+    if (( size > MIN_SIZE_BYTES )); then
+        echo "Model already present at $DEST_FILE ($(( size / 1024 / 1024 )) MB) — skipping."
+        exit 0
+    fi
+    echo "Existing $DEST_FILE looks truncated ($(( size / 1024 / 1024 )) MB) — re-downloading."
+    rm -f "$DEST_FILE"
+fi
+
+echo "Fetching Qwen3-0.6B-Q4_K_M.gguf (~400 MB) from Hugging Face..."
+curl -L --fail --progress-bar -o "$DEST_FILE" "$MODEL_URL"
+
+size=$(stat -f%z "$DEST_FILE" 2>/dev/null || stat -c%s "$DEST_FILE")
+if (( size < MIN_SIZE_BYTES )); then
+    echo "Downloaded file is suspiciously small ($(( size / 1024 / 1024 )) MB). Aborting." >&2
+    rm -f "$DEST_FILE"
+    exit 1
+fi
+
+echo "Model saved to $DEST_FILE ($(( size / 1024 / 1024 )) MB)."

--- a/KllamaDemo/shared/build.gradle.kts
+++ b/KllamaDemo/shared/build.gradle.kts
@@ -71,7 +71,14 @@ kotlin {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector")
+    // SIMD-accelerated CPU ops via JDK Vector API (incubator). The same
+    // flag set as :composeApp:run uses, so jvmTest exercise the SIMD path
+    // we ship in production.
+    jvmArgs(
+        "--add-modules", "jdk.incubator.vector",
+        "--enable-preview",
+        "-Dskainet.cpu.vector.enabled=true",
+    )
 }
 
 android {

--- a/KllamaDemo/shared/build.gradle.kts
+++ b/KllamaDemo/shared/build.gradle.kts
@@ -44,11 +44,16 @@ kotlin {
             implementation(libs.skainet.io.core)
             implementation(libs.skainet.io.gguf)
 
-            // SKaiNET-transformers: Llama + Qwen inference (DecoderGgufWeightLoader, QwenNetworkLoader)
-            implementation(libs.skainet.inference.llama)
-            implementation(libs.skainet.inference.qwen)
-            // SKaiNET LLM core - OptimizedLLMRuntime, Tokenizer, TokenizerFactory, GenerateExtensions
-            implementation(libs.skainet.llm)
+            // SKaiNET-transformers: Llama + Qwen inference. Promoted to api()
+            // so the composeApp playground UI can call Tokenizer / OptimizedLLMRuntime
+            // / QwenNetworkLoader directly.
+            api(libs.skainet.inference.llama)
+            api(libs.skainet.inference.qwen)
+            api(libs.skainet.llm)
+            api(libs.skainet.lang.core)
+            api(libs.skainet.backend.cpu)
+            api(libs.skainet.io.gguf)
+            api(libs.skainet.io.core)
         }
         jvmMain.dependencies {
             // SKaiNET KLlama (GGUFTokenizer, CpuAttentionBackend) - JVM only

--- a/KllamaDemo/shared/build.gradle.kts
+++ b/KllamaDemo/shared/build.gradle.kts
@@ -44,15 +44,16 @@ kotlin {
             implementation(libs.skainet.io.core)
             implementation(libs.skainet.io.gguf)
 
-            // SKaiNET-transformers: Llama inference (DecoderGgufWeightLoader, LlamaRuntime, etc.)
+            // SKaiNET-transformers: Llama + Qwen inference (DecoderGgufWeightLoader, QwenNetworkLoader)
             implementation(libs.skainet.inference.llama)
-            // SKaiNET LLM core - needed in common for DecoderModelMetadata supertype access
+            implementation(libs.skainet.inference.qwen)
+            // SKaiNET LLM core - OptimizedLLMRuntime, Tokenizer, TokenizerFactory, GenerateExtensions
             implementation(libs.skainet.llm)
         }
         jvmMain.dependencies {
             // SKaiNET KLlama (GGUFTokenizer, CpuAttentionBackend) - JVM only
             implementation(libs.skainet.kllama)
-            // SKaiNET Agent APIs (generateUntilStop, ChatMLTemplate)
+            // SKaiNET Agent APIs (ChatSession, ToolRegistry, ChatTemplate) - JVM only
             implementation(libs.skainet.kllama.agents)
         }
         commonTest.dependencies {

--- a/KllamaDemo/shared/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpike.kt
+++ b/KllamaDemo/shared/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpike.kt
@@ -1,0 +1,79 @@
+package sk.ainet.apps.kllama.chat.spike
+
+import kotlinx.io.Buffer
+import kotlin.time.TimeSource
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.generate
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.qwen.QwenNetworkLoader
+
+sealed interface QwenSpikeResult {
+    data class Success(
+        val tokenIds: List<Int>,
+        val loadMillis: Long,
+        val generateMillis: Long,
+    ) : QwenSpikeResult
+
+    data class Failure(val stage: String, val message: String) : QwenSpikeResult
+}
+
+/**
+ * Phase-0 smoke: build a Qwen model from raw GGUF bytes, wrap it in the
+ * unified runtime, generate 5 tokens starting from a single BOS token.
+ * Tokenizer is intentionally skipped — this test only proves the
+ * model + runtime pipeline works on the current target.
+ */
+suspend fun runQwenSpike(modelBytes: ByteArray): QwenSpikeResult {
+    val ctx = DirectCpuExecutionContext()
+    val timeSource = TimeSource.Monotonic
+
+    val model = try {
+        val loadStart = timeSource.markNow()
+        val sourceProvider = { Buffer().apply { write(modelBytes) } }
+        val m = QwenNetworkLoader
+            .fromGguf(sourceProvider, QuantPolicy.DEQUANTIZE_TO_FP32)
+            .load<FP32, Float>(ctx)
+        loadStart to m
+    } catch (e: Throwable) {
+        return QwenSpikeResult.Failure(
+            stage = "model-load",
+            message = "${e::class.simpleName}: ${e.message ?: "no message"}",
+        )
+    }
+
+    val (loadStart, qwen) = model
+    val loadMillis = loadStart.elapsedNow().inWholeMilliseconds
+
+    return try {
+        val runtime = OptimizedLLMRuntime(
+            model = qwen,
+            ctx = ctx,
+            mode = OptimizedLLMMode.DIRECT,
+            dtype = FP32::class,
+            bos = 1,
+        )
+
+        val tokens = mutableListOf<Int>()
+        val genStart = timeSource.markNow()
+        runtime.generate(
+            prompt = intArrayOf(1),
+            steps = 5,
+            temperature = 0f,
+        ) { id -> tokens += id }
+        val genMillis = genStart.elapsedNow().inWholeMilliseconds
+
+        QwenSpikeResult.Success(
+            tokenIds = tokens.toList(),
+            loadMillis = loadMillis,
+            generateMillis = genMillis,
+        )
+    } catch (e: Throwable) {
+        QwenSpikeResult.Failure(
+            stage = "runtime-or-generate",
+            message = "${e::class.simpleName}: ${e.message ?: "no message"}",
+        )
+    }
+}

--- a/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
+++ b/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
@@ -25,7 +25,7 @@ class QwenSpikeJvmTest {
         "commonMain",
         "composeResources",
         "files",
-        "qwen3-0.6b-Q4_K_M.gguf",
+        "qwen3-0.6b-Q3_K_S.gguf",
     ).normalize()
 
     @Test

--- a/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
+++ b/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
@@ -1,0 +1,51 @@
+package sk.ainet.apps.kllama.chat.spike
+
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Phase-0 spike on JVM: read the embedded Qwen GGUF directly from disk and
+ * run a 5-token generation. Verifies the QwenNetworkLoader -> OptimizedLLMRuntime
+ * chain actually produces tokens before we wire it through the app.
+ *
+ * Skips silently if the model file isn't present locally (so CI doesn't fail
+ * for contributors who haven't run the fetch script).
+ */
+class QwenSpikeJvmTest {
+
+    private val modelPath: java.nio.file.Path = Paths.get(
+        System.getProperty("user.dir"),
+        "..",
+        "composeApp",
+        "src",
+        "commonMain",
+        "composeResources",
+        "files",
+        "qwen3-0.6b-Q4_K_M.gguf",
+    ).normalize()
+
+    @Test
+    fun loads_model_and_generates_five_tokens() = runBlocking {
+        if (!Files.exists(modelPath)) {
+            println("[spike] model not present at $modelPath - run scripts/fetch-qwen-model.sh; skipping")
+            return@runBlocking
+        }
+
+        val bytes = Files.readAllBytes(modelPath)
+        println("[spike] loaded ${bytes.size / 1024 / 1024} MB of GGUF bytes")
+
+        when (val result = runQwenSpike(bytes)) {
+            is QwenSpikeResult.Success -> {
+                println("[spike] OK - tokens=${result.tokenIds} loadMs=${result.loadMillis} genMs=${result.generateMillis}")
+                assertTrue(result.tokenIds.size == 5, "expected 5 tokens, got ${result.tokenIds.size}")
+            }
+            is QwenSpikeResult.Failure -> {
+                fail("[spike] failed at stage='${result.stage}': ${result.message}")
+            }
+        }
+    }
+}

--- a/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
+++ b/KllamaDemo/shared/src/jvmTest/kotlin/sk/ainet/apps/kllama/chat/spike/QwenSpikeJvmTest.kt
@@ -25,7 +25,7 @@ class QwenSpikeJvmTest {
         "commonMain",
         "composeResources",
         "files",
-        "qwen3-0.6b-Q3_K_S.gguf",
+        "qwen3-0.6b-Q4_0.gguf",
     ).normalize()
 
     @Test


### PR DESCRIPTION
## Summary
Rebuilds KllamaDemo as a Compose Multiplatform / KMP / SKaiNET analog of the [Polo Club Transformer Explainer](https://poloclub.github.io/transformer-explainer/), running fully in the browser (and on JVM desktop, Android, iOS). The app embeds **Qwen3-0.6B (Q3_K_S, ~308 MB)** and visualizes what the transformer is doing as it generates each token.

### Tabs

The **Visualize** tab is the headline. The other five reuse the same loaded model to demonstrate related SKaiNET-transformers capabilities.

1. **Visualize** *(headline — new)* — type a prompt, click **Run prompt** / **Step**, see one token get generated at a time. Renders:
   - **Architecture diagram** — clickable vertical stack of `token_embed → 24 decoder blocks → output`. Selecting a block drives the panels below.
   - **Attention heatmap** — per-head `[seqLen × seqLen]` post-softmax weights captured from the SDPA softmax op via an `ExecutionObserver`. Falls back to a "fused SDPA kernel" notice if the kernel doesn't emit a discrete softmax.
   - **Residual stream bars** — the selected block's output activations, downsampled to 64 buckets, rendered as a bipolar bar chart.
   - **Top-10 next-token bars** — softmax probabilities of the most-likely continuations with decoded text labels.
2. **Tokenizer playground** — see Qwen's BPE breakdown of any text.
3. **Chat** — Qwen3 ChatML template inline, streaming tokens.
4. **Streaming completion** — raw prompt → continuation, no template.
5. **Translation (en↔zh)** — bilingual via system prompt.
6. **Tool calling** *(experimental)* — two-turn JSON tool-call round-trip with `get_current_time`.

### Plumbing for the explainer

- `sk.ainet.apps.kllama.chat.playground.explainer.InstrumentedExecutionContext` wraps `DirectCpuExecutionContext` with `ForwardHooks` (per-block `onForwardEnd` captures the residual) and an `ExecutionObserver` (captures `softmax` op results as attention heatmaps). Capture is toggled by a `captureEnabled` flag so the other five tabs pay zero per-forward overhead.
- `QwenModelHolder.stepInstrumented(tokenId, priorTokens, temperature)` returns a `StepSnapshot` containing the per-layer captures + the sampled token + a top-10 softmax breakdown.
- `ArchitectureSummary` is populated post-load from `OptimizedLLMRuntime.{nLayers, dim, vocabSize, seqLen}`.

### Model swap

- Quant changed from **Q4_K_M (397 MB)** to **Q3_K_S (308 MB)** for a lighter browser bundle. Same `QwenNetworkLoader` code path — Qwen3 architecture stays in `QWEN_ARCHITECTURES`.
- `scripts/fetch-qwen-model.sh` and the `fetchQwenModel` Gradle task were updated to fetch the new file. The script is idempotent; the Gradle task runs before every `compileKotlin*` / `compileJava*` and the Compose-resource copy tasks (the strict Gradle 9 dependency validator needed both wired).
- License unchanged: bundled Apache 2.0 text + NOTICE attributing the Qwen team.

### Build status (verified locally)

| Target | Artifact | Size |
| --- | --- | --- |
| wasmJs production | `composeApp/build/dist/wasmJs/productionExecutable/` | **324 MB** (down from 394 MB) |
| Android debug APK | `composeApp-debug.apk` | 685 MB |
| iOS Arm64 + Simulator Arm64 | frameworks linked | — |
| JVM `:shared:jvmTest --tests "*QwenSpike*"` | passes — loads 308 MB GGUF in ~40 s, generates 5 tokens in ~28 s | — |

### Known limitations (documented in the README + commit message)

- **Runtime KV-cache state advances across all tabs sharing the holder.** The explainer's semantics assume it's used first; switching to another tab and then back may give attention patterns that don't match the visible prompt. v2 will rebuild the runtime on "Reset".
- **`ArchitectureSummary` uses a synthetic `ModuleNode` tree.** `OptimizedLLMRuntime` keeps its `model` field private, so we can only enumerate `blk.N` names by index. A small upstream PR exposing the model root would let us walk per-block `attn / ffn / norm` children too.
- **Attention heatmap may be empty if the SDPA kernel fuses the softmax.** The `ExecutionObserver` only sees discrete `softmax` ops; the UI surfaces this clearly when no captures arrive.
- **Browser end-to-end run not yet verified.** The bundle builds; whether 600M params dequantized to FP32 fit within the WASM 2 GB memory cap during inference is the next manual check. If it OOMs, the path forward is `NATIVE_OPTIMIZED` quant support on wasmJs (upstream SKaiNET-transformers work).

## Test plan
- [x] `./gradlew :shared:jvmTest --tests "*QwenSpike*"` — pipeline validated on JVM.
- [x] `./gradlew :composeApp:wasmJsBrowserDistribution` — 324 MB production bundle including the embedded GGUF.
- [x] `./gradlew :composeApp:assembleDebug` — Android debug APK builds (685 MB, expected oversize).
- [x] `./gradlew :composeApp:linkDebugFrameworkIosArm64 :composeApp:linkDebugFrameworkIosSimulatorArm64` — iOS frameworks link.
- [ ] `./gradlew :composeApp:wasmJsBrowserDevelopmentRun` and exercise the Visualize tab in Chrome: Run prompt → see top-k populate, click through each block, confirm heatmap renders (or shows the fused-SDPA notice).
- [ ] `./gradlew :composeApp:run` and exercise the same flow on JVM desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)