### PR TITLE
Fix stale mavenLocal/version references in MnistJavaDemo README

### DIFF
--- a/MnistJavaDemo/README.md
+++ b/MnistJavaDemo/README.md
@@ -5,7 +5,7 @@ A CLI MNIST digit detector written in Java 21, demonstrating JVM interoperabilit
 ## Prerequisites
 
 - **Java 21+** (with preview features)
-- **SKaiNET 0.13.0** published to `mavenLocal` (`./gradlew publishToMavenLocal` from the SKaiNET root)
+- **SKaiNET 0.40.1** -- resolved directly from Maven Central, no local publish needed
 - **GGUF model file** -- a trained MNIST CNN model in GGUF format
 
 ## Usage
@@ -110,7 +110,7 @@ SKaiNET's `sequential` DSL uses `inline reified` type parameters -- a Kotlin com
 
 ## SKaiNET Dependencies
 
-All artifacts are consumed from `mavenLocal()` with the `-jvm` suffix (Kotlin Multiplatform JVM targets):
+All artifacts are consumed from Maven Central with the `-jvm` suffix (Kotlin Multiplatform JVM targets):
 
 - `skainet-lang-core-jvm` -- Tensor operations, Shape, DType
 - `skainet-lang-models-jvm` -- Module, sequential DSL
@@ -118,7 +118,7 @@ All artifacts are consumed from `mavenLocal()` with the `-jvm` suffix (Kotlin Mu
 - `skainet-data-transform-jvm` -- `Transform<I,O>`, `mnistPreprocessing()`, image transforms
 - `skainet-io-image-jvm` -- `PlatformBitmapImage` / image-to-tensor conversion
 - `skainet-io-gguf-jvm` -- GGUF model file reader
-- `skainet-data-basic-jvm` -- MNIST dataset loader
+- `skainet-data-simple-jvm` -- MNIST dataset loader
 - `skainet-compile-dag-jvm` -- Graph execution context for inference
 
 ## Running Tests


### PR DESCRIPTION
Prep for the 0.40.1 release: audited every README, CHANGELOG, and webapp.json in the repo for staleness. Everything else checked out (JSON all valid, screenshots all resolve, no other stale version/artifact mentions) except this one:

- Still said "SKaiNET 0.13.0 published to mavenLocal" -- the build has resolved purely from Maven Central for a long time now (settings.gradle.kts has no mavenLocal() at all), and the version is obviously years out of date.
- Still listed skainet-data-basic-jvm, which was renamed to skainet-data-simple-jvm starting at 0.36.0 -- missed when the catalog itself was updated for this release.